### PR TITLE
feat: integrate goodmetrics and instrument memcached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,10 +129,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -141,23 +170,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
- "tower",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -171,10 +226,29 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -199,6 +273,35 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bindgen"
@@ -250,7 +353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9a2a6a85b9cdadd64a1856ac5632afe0816518e20aadd372f4e4172aa94e2a"
 dependencies = [
  "autocfg",
- "bindgen",
+ "bindgen 0.70.1",
  "cmake",
  "fs_extra",
  "fslock",
@@ -405,6 +508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +577,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "exponential-histogram"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57118a0cda21ad08941ca4c2790a402d63ad03e442c1b4ee6d1a85d2485aa28a"
 
 [[package]]
 name = "fnv"
@@ -530,6 +665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-batch"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f444c45a1cb86f2a7e301469fd50a82084a60dadc25d94529a8312276ecb71a"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "pin-utils",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +791,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "goodmetrics"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec52f17558a9f01c5a2a8b73e4db788b53a6537eea789a0811f4915d7663eabc"
+dependencies = [
+ "bytes",
+ "exponential-histogram",
+ "futures",
+ "futures-batch",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "log",
+ "ordered-float",
+ "prost 0.13.5",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tonic 0.13.1",
+ "tower 0.5.2",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,7 +825,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
  "indexmap 2.9.0",
  "slab",
  "tokio",
@@ -679,10 +874,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -696,7 +911,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -722,9 +960,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -737,15 +975,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "rustls 0.23.27",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.32",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.6.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -809,6 +1120,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +1168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1204,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -968,18 +1303,18 @@ version = "0.50.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10181ece33b452732ece87748d5b722ff22e6bbeb028bb469f3a25efa46da324"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "derive_more",
  "futures",
- "h2",
- "hyper",
+ "h2 0.3.26",
+ "hyper 0.14.32",
  "log",
  "momento-protos",
  "rand",
  "serde",
  "serde_json",
  "thiserror",
- "tonic",
+ "tonic 0.10.2",
  "zstd",
 ]
 
@@ -989,8 +1324,8 @@ version = "0.122.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fcecfc2e01f759d1ac0d2f80969f8b6ccdfafe2bc874a968fb587d70627b4f"
 dependencies = [
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -1005,6 +1340,7 @@ dependencies = [
  "config",
  "crossbeam-channel",
  "futures",
+ "goodmetrics",
  "libc",
  "logger",
  "metriken",
@@ -1017,6 +1353,9 @@ dependencies = [
  "storage-types",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.26.2",
+ "tonic 0.13.1",
+ "webpki-roots 1.0.0",
 ]
 
 [[package]]
@@ -1040,6 +1379,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -1072,6 +1420,15 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "ordered-float"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1212,6 +1569,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1603,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -1247,6 +1624,19 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1439,6 +1829,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,8 +1849,23 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1459,7 +1877,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -1468,7 +1898,16 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -1478,6 +1917,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1525,7 +1976,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1660,6 +2124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +2145,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
@@ -1772,7 +2248,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -1849,28 +2335,58 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
- "base64",
+ "axum 0.6.20",
+ "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
- "prost",
- "rustls",
- "rustls-native-certs",
+ "prost 0.12.6",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum 0.8.4",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.10",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1886,6 +2402,25 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 2.9.0",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -1995,6 +2530,27 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "winapi"
@@ -2203,6 +2759,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ session = { git = "https://github.com/pelikan-io/pelikan.git", rev = "3309d317",
 storage-types = { git = "https://github.com/pelikan-io/pelikan.git", rev = "3309d317", package = "storage-types" }
 tokio = { version = "1.43.1", features = ["full"] }
 thiserror = "1.0.49"
+goodmetrics = "7.1.1"
+tokio-rustls = "0.26.2"
+webpki-roots = "1.0.0"
+tonic = "0.13.1"
 
 [profile.release]
 opt-level = 3

--- a/justfile
+++ b/justfile
@@ -1,0 +1,4 @@
+run-proxy:
+    echo "Running proxy..."
+    cargo run -- ./config/momento_proxy.toml
+

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -18,6 +18,7 @@ pub(crate) async fn handle_memcache_client(
     client: CacheClient,
     cache_name: String,
     flags: bool,
+    proxy_metrics: impl ProxyMetrics,
 ) {
     debug!("accepted memcache client, waiting for first byte to detect text or binary");
 
@@ -38,6 +39,7 @@ pub(crate) async fn handle_memcache_client(
                         cache_name,
                         protocol_memcache::BinaryProtocol::default(),
                         flags,
+                        proxy_metrics,
                     )
                     .await;
                     return;
@@ -48,6 +50,7 @@ pub(crate) async fn handle_memcache_client(
                         cache_name,
                         protocol_memcache::TextProtocol::default(),
                         flags,
+                        proxy_metrics,
                     )
                     .await;
                     return;
@@ -75,6 +78,7 @@ pub(crate) async fn handle_memcache_client_concrete(
         + Send
         + 'static,
     flags: bool,
+    proxy_metrics: impl ProxyMetrics,
 ) {
     debug!("accepted memcache binary client");
 
@@ -201,9 +205,16 @@ pub(crate) async fn handle_memcache_client_concrete(
 
                     let sequence = sequence.fetch_add(1, Ordering::Relaxed);
 
+                    let proxy_metrics = proxy_metrics.clone();
                     tokio::spawn(async move {
                         handle_memcache_request(
-                            sender, client, cache_name, sequence, request, flags,
+                            sender,
+                            client,
+                            cache_name,
+                            sequence,
+                            request,
+                            flags,
+                            proxy_metrics,
                         )
                         .await;
                     });
@@ -250,14 +261,36 @@ async fn handle_memcache_request(
     sequence: u64,
     request: protocol_memcache::Request,
     flags: bool,
+    proxy_metrics: impl ProxyMetrics,
 ) {
     let result = match request {
-        memcache::Request::Delete(ref r) => memcache::delete(&mut client, &cache_name, r).await,
-        memcache::Request::Get(ref r) => memcache::get(&mut client, &cache_name, r, flags).await,
-        memcache::Request::Set(ref r) => memcache::set(&mut client, &cache_name, r, flags).await,
+        memcache::Request::Delete(ref r) => {
+            with_rpc_call_guard(
+                proxy_metrics.begin_delete(),
+                memcache::delete(&mut client, &cache_name, r),
+            )
+            .await
+        }
+        memcache::Request::Get(ref r) => {
+            with_rpc_call_guard(
+                proxy_metrics.begin_get(),
+                memcache::get(&mut client, &cache_name, r, flags),
+            )
+            .await
+        }
+        memcache::Request::Set(ref r) => {
+            with_rpc_call_guard(
+                proxy_metrics.begin_set(),
+                memcache::set(&mut client, &cache_name, r, flags),
+            )
+            .await
+        }
         _ => {
             debug!("unsupported command: {}", request);
-            Err(Error::new(ErrorKind::Other, "unsupported"))
+            with_rpc_call_guard(proxy_metrics.begin_unimplemented(), async {
+                Err(Error::new(ErrorKind::Other, "unsupported"))
+            })
+            .await
         }
     };
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -266,28 +266,28 @@ async fn handle_memcache_request(
     let result = match request {
         memcache::Request::Delete(ref r) => {
             with_rpc_call_guard(
-                proxy_metrics.begin_delete(),
+                proxy_metrics.begin_memcached_delete(),
                 memcache::delete(&mut client, &cache_name, r),
             )
             .await
         }
         memcache::Request::Get(ref r) => {
             with_rpc_call_guard(
-                proxy_metrics.begin_get(),
+                proxy_metrics.begin_memcached_get(),
                 memcache::get(&mut client, &cache_name, r, flags),
             )
             .await
         }
         memcache::Request::Set(ref r) => {
             with_rpc_call_guard(
-                proxy_metrics.begin_set(),
+                proxy_metrics.begin_memcached_set(),
                 memcache::set(&mut client, &cache_name, r, flags),
             )
             .await
         }
         _ => {
             debug!("unsupported command: {}", request);
-            with_rpc_call_guard(proxy_metrics.begin_unimplemented(), async {
+            with_rpc_call_guard(proxy_metrics.begin_memcached_unimplemented(), async {
                 Err(Error::new(ErrorKind::Other, "unsupported"))
             })
             .await

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -13,6 +13,7 @@ pub(crate) async fn listener(
     cache_name: String,
     protocol: Protocol,
     flags: bool,
+    proxy_metrics: impl ProxyMetrics,
 ) {
     let client = client_builder.clone().build().unwrap_or_else(|e| {
         // Note: this will not happen since we validated the client build in the main thread already
@@ -29,12 +30,21 @@ pub(crate) async fn listener(
             let cache_name = cache_name.clone();
 
             // spawn a task for managing requests for the client
+            let proxy_metrics = proxy_metrics.clone();
             tokio::spawn(async move {
                 TCP_CONN_CURR.increment();
+                let _connection_metric = proxy_metrics.begin_connection();
+
                 match protocol {
                     Protocol::Memcache => {
-                        crate::frontend::handle_memcache_client(socket, client, cache_name, flags)
-                            .await;
+                        crate::frontend::handle_memcache_client(
+                            socket,
+                            client,
+                            cache_name,
+                            flags,
+                            proxy_metrics,
+                        )
+                        .await;
                     }
                     Protocol::Resp => {
                         crate::frontend::handle_resp_client(socket, client, cache_name).await;

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -1,0 +1,117 @@
+use goodmetrics::{
+    default_gauge_factory,
+    downstream::{get_client, OpenTelemetryDownstream, OpentelemetryBatcher},
+    pipeline::DimensionPosition,
+};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_rustls::rustls::RootCertStore;
+use tonic::metadata::MetadataValue;
+
+use super::{proxy::DefaultProxyMetrics, util::proxy_sum_gauge, RpcMetrics};
+
+pub struct ProxyMetricsBuilder {
+    batch_interval: Duration,
+    batch_capacity: usize,
+}
+
+impl ProxyMetricsBuilder {
+    pub fn new() -> Self {
+        Self {
+            batch_interval: Duration::from_secs(1),
+            batch_capacity: 128,
+        }
+    }
+
+    pub async fn build(self) -> Arc<DefaultProxyMetrics> {
+        let (batch_sender, batch_receiver) = mpsc::channel(self.batch_capacity);
+        let gauge_factory = default_gauge_factory();
+
+        let endpoint = get_environment_variable_or_none("MOMENTO_PROXY_OTLP_ENDPOINT");
+        let api_token = get_environment_variable_or_none("MOMENTO_PROXY_OTLP_API_TOKEN");
+
+        if endpoint.is_some() && api_token.is_some() {
+            info!("Configuring OTLP downstream with provided endpoint and API token");
+
+            // Set up the OTLP downstream
+            let channel = get_client(
+                endpoint.as_ref().unwrap(),
+                || {
+                    Some(RootCertStore {
+                        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec()
+                    })
+                },
+                goodmetrics::proto::opentelemetry::collector::metrics::v1::metrics_service_client::MetricsServiceClient::with_origin
+            ).expect("Failed to create client");
+
+            // Set up the OTLP downstream
+            let otlp_downstream = OpenTelemetryDownstream::new_with_dimensions(
+                channel,
+                Some((
+                    "api-token",
+                    MetadataValue::try_from(api_token.as_ref().unwrap()).unwrap(),
+                )),
+                get_chronosphere_base_environment_dimensions(),
+            );
+            tokio::spawn(otlp_downstream.send_batches_forever(batch_receiver));
+
+            // Set up the OpenTelemetry batcher
+            tokio::spawn(gauge_factory.clone().report_gauges_forever(
+                self.batch_interval,
+                batch_sender,
+                OpentelemetryBatcher,
+            ));
+        } else if endpoint.is_none() {
+            info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the MOMENTO_PROXY_OTLP_ENDPOINT environment variable to configure.");
+        } else {
+            info!("OTLP API token not provided, not configuring OTLP downstream. Set the MOMENTO_PROXY_OTLP_API_TOKEN environment variable to configure.");
+        }
+
+        let metrics = DefaultProxyMetrics {
+            get: RpcMetrics::new(gauge_factory, "get"),
+            set: RpcMetrics::new(gauge_factory, "set"),
+            delete: RpcMetrics::new(gauge_factory, "delete"),
+            unimplemented: RpcMetrics::new(gauge_factory, "unimplemented"),
+            current_connections: proxy_sum_gauge(gauge_factory, "current_connections"),
+        };
+
+        Arc::new(metrics)
+    }
+}
+
+fn get_chronosphere_base_environment_dimensions() -> DimensionPosition {
+    DimensionPosition::from_iter(
+        vec![
+            // Chronosphere requires a standard Otel Collor `service.instance.id` and `service.name`
+            // dimensions in order to ingest metrics, otherwise they are rejected.
+            // We don't really "need" a distinct value, we just need something, which
+            // will default to `unknown`. If we need something in the future, we can
+            // add that as necessary.
+            (
+                "service.instance.id",
+                get_environment_variable("SERVICE_INSTANCE_ID"),
+            ),
+            ("service.name", get_environment_variable("SERVICE_NAME")),
+        ]
+        .into_iter()
+        .map(|(n, v)| (n.into(), v.into())),
+    )
+}
+
+fn get_environment_variable(variable: &str) -> String {
+    match std::env::var(variable) {
+        Ok(val) => val,
+        Err(_) => {
+            info!(
+                "Environment variable {} not set, defaulting to 'unknown'",
+                variable
+            );
+            "unknown".to_string()
+        }
+    }
+}
+
+fn get_environment_variable_or_none(variable: &str) -> Option<String> {
+    std::env::var(variable).ok()
+}

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -74,7 +74,8 @@ impl ProxyMetricsBuilder {
             set: RpcMetrics::new(gauge_factory, "set"),
             delete: RpcMetrics::new(gauge_factory, "delete"),
             unimplemented: RpcMetrics::new(gauge_factory, "unimplemented"),
-            current_connections: proxy_sum_gauge(gauge_factory, "current_connections"),
+            connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
+            connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
         };
 
         Arc::new(metrics)

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -70,10 +70,10 @@ impl ProxyMetricsBuilder {
         }
 
         let metrics = DefaultProxyMetrics {
-            get: RpcMetrics::new(gauge_factory, "get"),
-            set: RpcMetrics::new(gauge_factory, "set"),
-            delete: RpcMetrics::new(gauge_factory, "delete"),
-            unimplemented: RpcMetrics::new(gauge_factory, "unimplemented"),
+            memcached_get: RpcMetrics::new(gauge_factory, "memcached_get"),
+            memcached_set: RpcMetrics::new(gauge_factory, "memcached_set"),
+            memcached_delete: RpcMetrics::new(gauge_factory, "memcached_delete"),
+            memcached_unimplemented: RpcMetrics::new(gauge_factory, "memcached_unimplemented"),
             connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
             connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
         };

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -31,41 +31,42 @@ impl ProxyMetricsBuilder {
         let endpoint = get_environment_variable_or_none("OTLP_ENDPOINT");
         let api_token = get_environment_variable_or_none("OTLP_API_TOKEN");
 
-        if endpoint.is_some() && api_token.is_some() {
-            info!("Configuring OTLP downstream with provided endpoint and API token");
+        match (&endpoint, &api_token) {
+            (Some(endpoint), Some(api_token)) => {
+                info!("Configuring OTLP downstream with provided endpoint and API token");
 
-            // Set up the OTLP downstream
-            let channel = get_client(
-                endpoint.as_ref().unwrap(),
-                || {
-                    Some(RootCertStore {
-                        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec()
-                    })
-                },
-                goodmetrics::proto::opentelemetry::collector::metrics::v1::metrics_service_client::MetricsServiceClient::with_origin
-            ).expect("Failed to create client");
+                // Set up the OTLP downstream
+                let channel = get_client(
+                    endpoint,
+                    || {
+                        Some(RootCertStore {
+                            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec()
+                        })
+                    },
+                    goodmetrics::proto::opentelemetry::collector::metrics::v1::metrics_service_client::MetricsServiceClient::with_origin
+                ).expect("Failed to create client");
 
-            // Set up the OTLP downstream
-            let otlp_downstream = OpenTelemetryDownstream::new_with_dimensions(
-                channel,
-                Some((
-                    "api-token",
-                    MetadataValue::try_from(api_token.as_ref().unwrap()).unwrap(),
-                )),
-                get_chronosphere_base_environment_dimensions(),
-            );
-            tokio::spawn(otlp_downstream.send_batches_forever(batch_receiver));
+                // Set up the OTLP downstream
+                let otlp_downstream = OpenTelemetryDownstream::new_with_dimensions(
+                    channel,
+                    Some(("api-token", MetadataValue::try_from(api_token).unwrap())),
+                    get_base_environment_dimensions(),
+                );
+                tokio::spawn(otlp_downstream.send_batches_forever(batch_receiver));
 
-            // Set up the OpenTelemetry batcher
-            tokio::spawn(gauge_factory.clone().report_gauges_forever(
-                self.batch_interval,
-                batch_sender,
-                OpentelemetryBatcher,
-            ));
-        } else if endpoint.is_none() {
-            info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the OTLP_ENDPOINT environment variable to configure.");
-        } else {
-            info!("OTLP API token not provided, not configuring OTLP downstream. Set the OTLP_API_TOKEN environment variable to configure.");
+                // Set up the OpenTelemetry batcher
+                tokio::spawn(gauge_factory.clone().report_gauges_forever(
+                    self.batch_interval,
+                    batch_sender,
+                    OpentelemetryBatcher,
+                ));
+            }
+            (None, _) => {
+                info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the OTLP_ENDPOINT environment variable to configure.");
+            }
+            (_, None) => {
+                info!("OTLP API token not provided, not configuring OTLP downstream. Set the OTLP_API_TOKEN environment variable to configure.");
+            }
         }
 
         let metrics = DefaultProxyMetrics {
@@ -80,10 +81,10 @@ impl ProxyMetricsBuilder {
     }
 }
 
-fn get_chronosphere_base_environment_dimensions() -> DimensionPosition {
+fn get_base_environment_dimensions() -> DimensionPosition {
     DimensionPosition::from_iter(
         vec![
-            // Chronosphere requires a standard Otel Collor `service.instance.id` and `service.name`
+            // We require a standard Otel Collector `service.instance.id` and `service.name`
             // dimensions in order to ingest metrics, otherwise they are rejected.
             // We don't really "need" a distinct value, we just need something, which
             // will default to `unknown`. If we need something in the future, we can

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -28,8 +28,8 @@ impl ProxyMetricsBuilder {
         let (batch_sender, batch_receiver) = mpsc::channel(self.batch_capacity);
         let gauge_factory = default_gauge_factory();
 
-        let endpoint = get_environment_variable_or_none("MOMENTO_PROXY_OTLP_ENDPOINT");
-        let api_token = get_environment_variable_or_none("MOMENTO_PROXY_OTLP_API_TOKEN");
+        let endpoint = get_environment_variable_or_none("OTLP_ENDPOINT");
+        let api_token = get_environment_variable_or_none("OTLP_API_TOKEN");
 
         if endpoint.is_some() && api_token.is_some() {
             info!("Configuring OTLP downstream with provided endpoint and API token");
@@ -63,9 +63,9 @@ impl ProxyMetricsBuilder {
                 OpentelemetryBatcher,
             ));
         } else if endpoint.is_none() {
-            info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the MOMENTO_PROXY_OTLP_ENDPOINT environment variable to configure.");
+            info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the OTLP_ENDPOINT environment variable to configure.");
         } else {
-            info!("OTLP API token not provided, not configuring OTLP downstream. Set the MOMENTO_PROXY_OTLP_API_TOKEN environment variable to configure.");
+            info!("OTLP API token not provided, not configuring OTLP downstream. Set the OTLP_API_TOKEN environment variable to configure.");
         }
 
         let metrics = DefaultProxyMetrics {

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -1,0 +1,20 @@
+use goodmetrics::SumHandle;
+
+pub struct ConnectionGuard {
+    counter: SumHandle,
+}
+
+impl ConnectionGuard {
+    /// Create a new guard, immediately bumping the counter.
+    pub fn new(counter: SumHandle) -> Self {
+        counter.observe(1);
+        Self { counter }
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        // -1 when this guard goes out of scope
+        self.counter.observe(-1);
+    }
+}

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -1,20 +1,21 @@
 use goodmetrics::SumHandle;
 
 pub struct ConnectionGuard {
-    counter: SumHandle,
+    connections_closed: SumHandle,
 }
 
 impl ConnectionGuard {
-    /// Create a new guard, immediately bumping the counter.
-    pub fn new(counter: SumHandle) -> Self {
-        counter.observe(1);
-        Self { counter }
+    /// Creates a new `ConnectionGuard` instance.
+    /// This instance will increment the `connections_opened` counter
+    pub fn new(connections_opened: SumHandle, connections_closed: SumHandle) -> Self {
+        connections_opened.observe(1);
+        Self { connections_closed }
     }
 }
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
-        // -1 when this guard goes out of scope
-        self.counter.observe(-1);
+        // When the guard is dropped, we assume the connection is closed.
+        self.connections_closed.observe(1);
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -75,3 +75,14 @@ pub static RU_NVCSW: Counter = Counter::new();
 
 #[metric(name = "ru_nivcsw")]
 pub static RU_NIVCSW: Counter = Counter::new();
+
+mod builder;
+mod connection;
+mod proxy;
+mod rpc;
+pub mod util;
+
+pub use builder::ProxyMetricsBuilder;
+pub use connection::ConnectionGuard;
+pub use proxy::{DefaultProxyMetrics, ProxyMetrics};
+pub use rpc::{with_rpc_call_guard, RpcCallGuard, RpcMetrics};

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use super::ConnectionGuard;
+use goodmetrics::SumHandle;
+
+use super::{RpcCallGuard, RpcMetrics};
+
+pub trait ProxyMetrics: Clone + Send + Sync + 'static {
+    fn begin_connection(&self) -> ConnectionGuard;
+    fn begin_get(&self) -> RpcCallGuard;
+    fn begin_set(&self) -> RpcCallGuard;
+    fn begin_delete(&self) -> RpcCallGuard;
+    fn begin_unimplemented(&self) -> RpcCallGuard;
+}
+
+#[derive(Clone, Debug)]
+pub struct DefaultProxyMetrics {
+    pub(crate) get: RpcMetrics,
+    pub(crate) set: RpcMetrics,
+    pub(crate) delete: RpcMetrics,
+    pub(crate) unimplemented: RpcMetrics,
+    pub(crate) current_connections: SumHandle,
+}
+
+impl ProxyMetrics for DefaultProxyMetrics {
+    fn begin_connection(&self) -> ConnectionGuard {
+        ConnectionGuard::new(self.current_connections.clone())
+    }
+
+    fn begin_get(&self) -> RpcCallGuard {
+        self.get.record_api_call()
+    }
+
+    fn begin_set(&self) -> RpcCallGuard {
+        self.set.record_api_call()
+    }
+
+    fn begin_delete(&self) -> RpcCallGuard {
+        self.delete.record_api_call()
+    }
+
+    fn begin_unimplemented(&self) -> RpcCallGuard {
+        self.unimplemented.record_api_call()
+    }
+}
+
+impl ProxyMetrics for Arc<DefaultProxyMetrics> {
+    fn begin_connection(&self) -> ConnectionGuard {
+        self.as_ref().begin_connection()
+    }
+
+    fn begin_get(&self) -> RpcCallGuard {
+        self.as_ref().begin_get()
+    }
+
+    fn begin_set(&self) -> RpcCallGuard {
+        self.as_ref().begin_set()
+    }
+
+    fn begin_delete(&self) -> RpcCallGuard {
+        self.as_ref().begin_delete()
+    }
+
+    fn begin_unimplemented(&self) -> RpcCallGuard {
+        self.as_ref().begin_unimplemented()
+    }
+}

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -7,18 +7,18 @@ use super::{RpcCallGuard, RpcMetrics};
 
 pub trait ProxyMetrics: Clone + Send + Sync + 'static {
     fn begin_connection(&self) -> ConnectionGuard;
-    fn begin_get(&self) -> RpcCallGuard;
-    fn begin_set(&self) -> RpcCallGuard;
-    fn begin_delete(&self) -> RpcCallGuard;
-    fn begin_unimplemented(&self) -> RpcCallGuard;
+    fn begin_memcached_get(&self) -> RpcCallGuard;
+    fn begin_memcached_set(&self) -> RpcCallGuard;
+    fn begin_memcached_delete(&self) -> RpcCallGuard;
+    fn begin_memcached_unimplemented(&self) -> RpcCallGuard;
 }
 
 #[derive(Clone, Debug)]
 pub struct DefaultProxyMetrics {
-    pub(crate) get: RpcMetrics,
-    pub(crate) set: RpcMetrics,
-    pub(crate) delete: RpcMetrics,
-    pub(crate) unimplemented: RpcMetrics,
+    pub(crate) memcached_get: RpcMetrics,
+    pub(crate) memcached_set: RpcMetrics,
+    pub(crate) memcached_delete: RpcMetrics,
+    pub(crate) memcached_unimplemented: RpcMetrics,
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
 }
@@ -31,20 +31,20 @@ impl ProxyMetrics for DefaultProxyMetrics {
         )
     }
 
-    fn begin_get(&self) -> RpcCallGuard {
-        self.get.record_api_call()
+    fn begin_memcached_get(&self) -> RpcCallGuard {
+        self.memcached_get.record_api_call()
     }
 
-    fn begin_set(&self) -> RpcCallGuard {
-        self.set.record_api_call()
+    fn begin_memcached_set(&self) -> RpcCallGuard {
+        self.memcached_set.record_api_call()
     }
 
-    fn begin_delete(&self) -> RpcCallGuard {
-        self.delete.record_api_call()
+    fn begin_memcached_delete(&self) -> RpcCallGuard {
+        self.memcached_delete.record_api_call()
     }
 
-    fn begin_unimplemented(&self) -> RpcCallGuard {
-        self.unimplemented.record_api_call()
+    fn begin_memcached_unimplemented(&self) -> RpcCallGuard {
+        self.memcached_unimplemented.record_api_call()
     }
 }
 
@@ -53,19 +53,19 @@ impl ProxyMetrics for Arc<DefaultProxyMetrics> {
         self.as_ref().begin_connection()
     }
 
-    fn begin_get(&self) -> RpcCallGuard {
-        self.as_ref().begin_get()
+    fn begin_memcached_get(&self) -> RpcCallGuard {
+        self.as_ref().begin_memcached_get()
     }
 
-    fn begin_set(&self) -> RpcCallGuard {
-        self.as_ref().begin_set()
+    fn begin_memcached_set(&self) -> RpcCallGuard {
+        self.as_ref().begin_memcached_set()
     }
 
-    fn begin_delete(&self) -> RpcCallGuard {
-        self.as_ref().begin_delete()
+    fn begin_memcached_delete(&self) -> RpcCallGuard {
+        self.as_ref().begin_memcached_delete()
     }
 
-    fn begin_unimplemented(&self) -> RpcCallGuard {
-        self.as_ref().begin_unimplemented()
+    fn begin_memcached_unimplemented(&self) -> RpcCallGuard {
+        self.as_ref().begin_memcached_unimplemented()
     }
 }

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -19,12 +19,16 @@ pub struct DefaultProxyMetrics {
     pub(crate) set: RpcMetrics,
     pub(crate) delete: RpcMetrics,
     pub(crate) unimplemented: RpcMetrics,
-    pub(crate) current_connections: SumHandle,
+    pub(crate) connections_opened: SumHandle,
+    pub(crate) connections_closed: SumHandle,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
     fn begin_connection(&self) -> ConnectionGuard {
-        ConnectionGuard::new(self.current_connections.clone())
+        ConnectionGuard::new(
+            self.connections_opened.clone(),
+            self.connections_closed.clone(),
+        )
     }
 
     fn begin_get(&self) -> RpcCallGuard {

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -1,0 +1,109 @@
+use std::{
+    future::Future,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use clocksource::coarse::Instant;
+use goodmetrics::{GaugeFactory, HistogramHandle};
+
+use super::util::{
+    proxy_request_latency_error_histogram, proxy_request_latency_ok_histogram,
+    proxy_request_latency_timeout_histogram,
+};
+
+#[derive(Clone, Debug)]
+pub struct RpcMetrics {
+    latency_ok: HistogramHandle,
+    latency_error: HistogramHandle,
+    latency_timeout: HistogramHandle,
+}
+
+impl RpcMetrics {
+    pub fn new(gauge_factory: &GaugeFactory, rpc: &'static str) -> Self {
+        Self {
+            latency_ok: proxy_request_latency_ok_histogram(gauge_factory, rpc),
+            latency_error: proxy_request_latency_error_histogram(gauge_factory, rpc),
+            latency_timeout: proxy_request_latency_timeout_histogram(gauge_factory, rpc),
+        }
+    }
+
+    pub fn record_api_call(&self) -> RpcCallGuard {
+        RpcCallGuard::new(
+            self.latency_ok.clone(),
+            self.latency_error.clone(),
+            self.latency_timeout.clone(),
+        )
+    }
+}
+
+pub struct RpcCallGuard {
+    start_time: Instant,
+    latency_ok: HistogramHandle,
+    latency_error: HistogramHandle,
+    latency_timeout: HistogramHandle,
+    recorded: AtomicBool,
+}
+
+impl RpcCallGuard {
+    pub fn new(
+        latency_ok: HistogramHandle,
+        latency_error: HistogramHandle,
+        latency_timeout: HistogramHandle,
+    ) -> Self {
+        Self {
+            start_time: Instant::now(),
+            latency_ok,
+            latency_error,
+            latency_timeout,
+            recorded: AtomicBool::new(false),
+        }
+    }
+
+    pub fn complete_ok(&mut self) {
+        if let Ok(false) =
+            self.recorded
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            self.latency_ok
+                .observe(self.start_time.elapsed().as_nanos() as i64);
+        }
+    }
+
+    pub fn complete_error(&mut self) {
+        if let Ok(false) =
+            self.recorded
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            self.latency_error
+                .observe(self.start_time.elapsed().as_nanos() as i64);
+        }
+    }
+
+    pub fn complete<T, E>(&mut self, result: &Result<T, E>) {
+        match result {
+            Ok(_) => self.complete_ok(),
+            Err(_) => self.complete_error(),
+        };
+    }
+}
+
+impl Drop for RpcCallGuard {
+    fn drop(&mut self) {
+        if let Ok(false) =
+            self.recorded
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            self.latency_timeout
+                .observe(self.start_time.elapsed().as_nanos() as i64);
+        }
+    }
+}
+
+pub async fn with_rpc_call_guard<T, E, F>(mut recorder: RpcCallGuard, fut: F) -> Result<T, E>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    let result = fut.await;
+    recorder.complete(&result);
+    result
+}

--- a/src/metrics/util.rs
+++ b/src/metrics/util.rs
@@ -1,0 +1,35 @@
+use goodmetrics::{GaugeDimensions, GaugeFactory, HistogramHandle, SumHandle};
+
+pub fn proxy_sum_gauge(g: &GaugeFactory, name: &'static str) -> SumHandle {
+    g.dimensioned_gauge_sum("momento_proxy", name, Default::default())
+}
+
+fn proxy_request_latency_histogram(
+    gauge_factory: &GaugeFactory,
+    rpc: &'static str,
+    result: &'static str,
+) -> HistogramHandle {
+    gauge_factory.dimensioned_gauge_histogram(
+        "momento_proxy",
+        "latency",
+        GaugeDimensions::new([("rpc", rpc), ("result", result)]),
+    )
+}
+
+pub fn proxy_request_latency_ok_histogram(g: &GaugeFactory, rpc: &'static str) -> HistogramHandle {
+    proxy_request_latency_histogram(g, rpc, "ok")
+}
+
+pub fn proxy_request_latency_error_histogram(
+    gauge_factory: &GaugeFactory,
+    rpc: &'static str,
+) -> HistogramHandle {
+    proxy_request_latency_histogram(gauge_factory, rpc, "error")
+}
+
+pub fn proxy_request_latency_timeout_histogram(
+    gauge_factory: &GaugeFactory,
+    rpc: &'static str,
+) -> HistogramHandle {
+    proxy_request_latency_histogram(gauge_factory, rpc, "timeout")
+}


### PR DESCRIPTION
# Summary

This PR wires in the `Goodmetrics`-based metrics client alongside the existing `metriken` instrumentation. For now we limit the metrics instrumentation to the Momento memcached proxy. We limit metrics to current connection count, number of requests, request latency, and request status (ok vs error).

See https://github.com/pelikan-io/pelikan/pull/149 for the original PR vs Pelikan.

# Overview of changes

## Momento proxy Cargo.toml

- Added goodmetrics as a dependency to Momento proxy and supporting libraries

## Metrics integration

- Added new metrics code to `src/proxy/momento/src/metrics`
   - `builder.rs` - `ProxyMetricsBuilder` spins up the gauge factory, OTLP downstream, and batch sender
   - `proxy.rs` - `ProxyMetric` trait + `DefaultProxyMetrics` implementation
   - `rpc.rs` - `RpcCallGuard` (RAII timer + ok/error counters) and `with_rpc_call_guard` helper
   - `connection.rs` - `ConnectionGuard` (RAII for connection count)
   - `util.rs` - guage constructors
 - Main: builds the proxy metrics
 - Listener: spawns `ConnectionGuard` in each connection task
 - Frontend: wraps each Memcache command using `with_rpc_call_guard` for timing + result counts
 - Metriken: left untouched

# Verification

1. Edit the momento proxy config per your cache settings
1. cargo run --bin=momento_proxy -- ./config/momento_proxy.toml with the following environment variables set
  -  `MOMENTO_AUTHENTICATION` - Momento API key
  - `OTLP_ENDPOINT` - open telemetry endpoint to push metrics
  - `OTLP_API_TOKEN` - API token for the above with write access
  - (Optional) `SERVICE_INSTANCE_ID`
  - (Optional) `SERVICE_NAME`
1. Run Memcache client against `localhost:11211`; confirm both Metriken and Goodmetrics counters increment

![image](https://github.com/user-attachments/assets/423a6642-c711-4fc6-b762-ed6691fbb0b5)

![image](https://github.com/user-attachments/assets/c3f72335-74d3-4804-8e3b-88e8290a6341)

# Review considerations

- Metric names, dimensions
- Naming to account for memcache vs resp, memcache text vs memcache binary
- Thread-safety, memory efficiency
- Goodmetrics setup, batching configuration, etc