### PR TITLE
chore: enable publishing to Docker hub

### DIFF
--- a/.github/workflows/momento-proxy-container-publish.yml
+++ b/.github/workflows/momento-proxy-container-publish.yml
@@ -19,45 +19,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-#      - name: Set release
-#        id: semrel
-#        uses: go-semantic-release/action@v1
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          allow-initial-development-versions: true
-#          force-bump-patch-version: true
-#
-#      - name: Log in to Docker Hub
-#        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-#        with:
-#          username: ${{ secrets.DOCKER_USER }}
-#          password: ${{ secrets.DOCKER_PASSWORD }}
-#
-#      - name: Build and push Docker image
-#        id: push
-#        uses: docker/build-push-action@v6
-#        with:
-#          push: true
-#          platforms: linux/amd64,linux/arm64
-#          tags: gomomento/momento-proxy:latest, gomomento/momento-proxy:${{ steps.semrel.outputs.version }}
+      - name: Set release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true
+          force-bump-patch-version: true
 
-      - name: Build Docker image
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v6
         with:
-          context: .
-          push: false
-          load: true  # This loads the image into the Docker daemon
-          tags: gomomento/momento-proxy:test
-
-      - name: Verify image exists
-        run: docker images | grep momento-proxy
-
-      - name: Save Docker image
-        run: docker save gomomento/momento-proxy:test > momento-proxy.tar
-
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-image
-          path: momento-proxy.tar
-          retention-days: 1
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: gomomento/momento-proxy:latest, gomomento/momento-proxy:${{ steps.semrel.outputs.version }}

--- a/.github/workflows/momento-proxy-container-publish.yml
+++ b/.github/workflows/momento-proxy-container-publish.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_USER: ${{secrets.DOCKER_USER}}
-      DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
     steps:
       - uses: actions/checkout@v3
 
@@ -30,8 +27,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
I was able to download and run the docker image produced by the previous version of the action.