### PR TITLE
proxy cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,11 +1414,13 @@ dependencies = [
  "protocol-admin",
  "protocol-memcache",
  "protocol-resp",
+ "serde",
  "session",
  "storage-types",
  "thiserror",
  "tokio",
  "tokio-rustls 0.26.2",
+ "toml",
  "tonic 0.13.1",
  "webpki-roots 1.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -528,6 +528,15 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -753,6 +762,20 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -1200,6 +1223,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1343,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "momento"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1408,7 @@ dependencies = [
  "libc",
  "logger",
  "metriken",
+ "moka",
  "momento",
  "pelikan-net",
  "protocol-admin",
@@ -1372,6 +1437,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1429,6 +1504,12 @@ checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1552,6 +1633,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -1759,8 +1846,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1771,8 +1867,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1954,6 +2056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,6 +2270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2293,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -2469,6 +2602,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2494,6 +2657,21 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2575,6 +2753,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +2910,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,10 @@ protocol-admin = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4af
 protocol-memcache = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "protocol-memcache" }
 protocol-resp = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "protocol-resp" }
 session = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "session" }
+serde = { version = "1.0" }
 storage-types = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "storage-types" }
 tokio = { version = "1.43.1", features = ["full"] }
+toml = { version = "0.8" }
 thiserror = "1.0.49"
 goodmetrics = "7.1.1"
 tokio-rustls = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.31"
 libc = "0.2.149"
 logger = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "logger" }
 metriken = "0.7.0"
+moka = { version = "0.12", features = ["sync"] }
 momento = "0.52.0"
 pelikan-net = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "pelikan-net", features = ["metrics"] }
 protocol-admin = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "protocol-admin" }

--- a/config/momento_proxy.toml
+++ b/config/momento_proxy.toml
@@ -24,6 +24,12 @@ default_ttl = 900
 # The number of connections to the service for this cache.
 # Defaults to 4
 # connection_count = 4
+# The amount of ram to try to use locally caching get results (only supported on memcached currently)
+# 0 to disable
+# memory_cache_bytes = 0
+# How long to keep get results in memory (only supported on memcached currently)
+# 0 means no expiration
+# memory_cache_ttl_seconds = 0
 # the protocol can be "memcache" or "resp" (Redis), the default is memcache
 # protocol = "memcache"
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,109 @@
+use std::{
+    borrow::Borrow, mem::size_of, time::{Duration, Instant, SystemTime, UNIX_EPOCH}
+};
+
+use moka::{Expiry, sync::Cache};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheValue {
+    Memcached { value: protocol_memcache::Value },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheEntry {
+    value: CacheValue,
+    expire_at: Instant,
+}
+
+impl CacheEntry {
+    pub fn _expiry_epoch_seconds(&self) -> i64 {
+        match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(n) => {
+                n.as_secs() as i64 + self.expire_at.duration_since(Instant::now()).as_secs() as i64
+            }
+            Err(_) => 0,
+        }
+    }
+
+    pub fn into_value(self) -> CacheValue {
+        self.value
+    }
+}
+
+#[derive(Clone)]
+pub struct MCache {
+    cache: Cache<KeyType, CacheEntry>,
+    ttl: Duration,
+}
+
+fn weigh(key: &KeyType, value: &CacheEntry) -> u32 {
+    (key.len()
+        + match &value.value {
+            CacheValue::Memcached { value } => value.len().unwrap_or_default(),
+        }
+        + size_of::<protocol_memcache::Value>()) as u32
+}
+
+struct MCacheExpiry;
+
+type KeyType = Vec<u8>;
+
+impl Expiry<KeyType, CacheEntry> for MCacheExpiry {
+    /// Returns the duration of the expiration of the value that was just
+    /// created.
+    fn expire_after_create(
+        &self,
+        _key: &KeyType,
+        value: &CacheEntry,
+        current_time: Instant,
+    ) -> Option<Duration> {
+        Some(value.expire_at.saturating_duration_since(current_time))
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &KeyType,
+        value: &CacheEntry,
+        updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(value.expire_at.saturating_duration_since(updated_at))
+    }
+}
+
+impl MCache {
+    pub fn new(max_bytes: usize, ttl: Duration) -> Self {
+        let cache = Cache::builder()
+            .max_capacity(max_bytes as u64)
+            .weigher(weigh)
+            .expire_after(MCacheExpiry)
+            .build();
+        Self { cache, ttl }
+    }
+
+    pub fn get<Q>(&self, key: &Q) -> Option<CacheEntry>
+    where 
+        KeyType: Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.cache.get(&key)
+    }
+
+    pub fn set(&self, key: KeyType, value: impl Into<CacheValue>) {
+        self.cache.insert(
+            key,
+            CacheEntry {
+                value: value.into(),
+                expire_at: Instant::now() + self.ttl,
+            },
+        )
+    }
+
+    pub fn delete<Q>(&self, key: &Q) -> Option<CacheValue>
+    where 
+        KeyType: Borrow<Q>,
+        Q: std::hash::Hash + Eq + ?Sized,
+    {
+        self.cache.remove(key).map(|e| e.value)
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -78,7 +78,7 @@ impl MCache {
             .weigher(weigh)
             .expire_after(MCacheExpiry)
             .build();
-        Self { cache, ttl }
+        Self { cache, ttl: std::cmp::min(ttl, Duration::from_secs(5 * 365 * 24 * 3600)) }
     }
 
     pub fn get<Q>(&self, key: &Q) -> Option<CacheEntry>

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -3,7 +3,7 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::*;
-use ::config::momento_proxy::Protocol;
+use momento_proxy::Protocol;
 use momento::CacheClientBuilder;
 use pelikan_net::{TCP_ACCEPT, TCP_CLOSE, TCP_CONN_CURR};
 

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -14,6 +14,7 @@ pub(crate) async fn listener(
     protocol: Protocol,
     flags: bool,
     proxy_metrics: impl ProxyMetrics,
+    memory_cache: Option<MCache>,
 ) {
     // Establishing a gRPC connection is expensive, so the client needs to be created outside the
     // loop and reused to avoid paying that cost with each request. A Momento client can handle 100
@@ -35,6 +36,8 @@ pub(crate) async fn listener(
 
             // spawn a task for managing requests for the client
             let proxy_metrics = proxy_metrics.clone();
+            let memory_cache = memory_cache.clone();
+
             tokio::spawn(async move {
                 TCP_CONN_CURR.increment();
                 let _connection_metric = proxy_metrics.begin_connection();
@@ -47,6 +50,7 @@ pub(crate) async fn listener(
                             cache_name,
                             flags,
                             proxy_metrics,
+                            memory_cache,
                         )
                         .await;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate logger;
 
+use cache::MCache;
 use ::config::{AdminConfig, MomentoProxyConfig, TimeType};
 use backtrace::Backtrace;
 use clap::{Arg, Command};
@@ -36,6 +37,7 @@ const S: u64 = 1_000_000_000; // one second in nanoseconds
 const US: u64 = 1_000; // one microsecond in nanoseconds
 
 mod admin;
+mod cache;
 mod error;
 mod frontend;
 mod klog;
@@ -312,6 +314,19 @@ async fn spawn(
             );
             let tcp_listener =
                 TcpListener::from_std(tcp_listener).expect("could not convert to tokio listener");
+
+            let local_cache_bytes = cache.memory_cache_bytes();
+            let local_cache = if 0 < local_cache_bytes {
+                let ttl = if cache.memory_cache_ttl_seconds() == 0 {
+                    Duration::MAX
+                } else {
+                    Duration::from_secs(cache.memory_cache_ttl_seconds() as u64)
+                };
+                Some(MCache::new(cache.memory_cache_bytes(), ttl))
+            } else {
+                None
+            };
+
             listener::listener(
                 tcp_listener,
                 client_builder,
@@ -319,6 +334,7 @@ async fn spawn(
                 cache.protocol(),
                 cache.flags(),
                 proxy_metrics,
+                local_cache,
             )
             .await;
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,10 @@
 extern crate logger;
 
 use cache::MCache;
-use ::config::{AdminConfig, MomentoProxyConfig, TimeType};
+use ::config::{AdminConfig, TimeType};
 use backtrace::Backtrace;
 use clap::{Arg, Command};
+use momento_proxy::MomentoProxyConfig;
 use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
@@ -43,6 +44,7 @@ mod frontend;
 mod klog;
 mod listener;
 mod metrics;
+mod momento_proxy;
 mod protocol;
 
 pub use metrics::*;

--- a/src/momento_proxy.rs
+++ b/src/momento_proxy.rs
@@ -1,0 +1,173 @@
+use core::num::NonZeroU64;
+use std::net::AddrParseError;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use config::Admin;
+use config::AdminConfig;
+use config::Debug;
+use config::DebugConfig;
+use config::Klog;
+use config::KlogConfig;
+use serde::{Deserialize, Serialize};
+
+use std::io::Read;
+
+#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum Protocol {
+    Memcache,
+    Resp,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Self::Memcache
+    }
+}
+
+// support for memcache flags is on by default
+fn flags() -> bool {
+    true
+}
+
+// struct definitions
+#[derive(Clone, Serialize, Default, Deserialize, Debug)]
+pub struct MomentoProxyConfig {
+    // application modules
+    #[serde(default)]
+    admin: Admin,
+    #[serde(default)]
+    proxy: Proxy,
+    #[serde(default)]
+    cache: Vec<Cache>,
+    #[serde(default)]
+    debug: Debug,
+    #[serde(default)]
+    klog: Klog,
+}
+
+#[derive(Default, Clone, Copy, Serialize, Deserialize, Debug)]
+pub struct Proxy {
+    threads: Option<usize>,
+}
+
+// definitions
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Cache {
+    host: String,
+    port: String,
+    cache_name: String,
+    default_ttl: NonZeroU64,
+    #[serde(default = "four")]
+    connection_count: NonZeroUsize,
+    #[serde(default)]
+    protocol: Protocol,
+    #[serde(default = "flags")]
+    flags: bool,
+    /// 0 to disable
+    #[serde(default)]
+    memory_cache_bytes: usize,
+    /// 0 means no expiration
+    #[serde(default)]
+    memory_cache_ttl_seconds: u64,
+}
+
+const fn four() -> NonZeroUsize {
+    NonZeroUsize::new(4).expect("4 is nonzero")
+}
+
+// implementation
+impl Cache {
+    /// Host address to listen on
+    pub fn host(&self) -> String {
+        self.host.clone()
+    }
+
+    /// Port to listen on
+    pub fn port(&self) -> String {
+        self.port.clone()
+    }
+
+    /// Return the result of parsing the host and port
+    pub fn socket_addr(&self) -> Result<SocketAddr, AddrParseError> {
+        format!("{}:{}", self.host(), self.port()).parse()
+    }
+
+    /// Returns the name of the momento cache that requests will be sent to
+    pub fn cache_name(&self) -> String {
+        self.cache_name.clone()
+    }
+
+    /// The default TTL (in seconds) for
+    pub fn default_ttl(&self) -> Duration {
+        Duration::from_secs(self.default_ttl.get())
+    }
+
+    pub fn connection_count(&self) -> usize {
+        self.connection_count.get()
+    }
+
+    pub fn protocol(&self) -> Protocol {
+        self.protocol
+    }
+
+    pub fn flags(&self) -> bool {
+        self.flags
+    }
+
+    /// 0 to disable
+    pub fn memory_cache_bytes(&self) -> usize {
+        self.memory_cache_bytes
+    }
+    /// 0 means no expiration
+    pub fn memory_cache_ttl_seconds(&self) -> u64 {
+        self.memory_cache_ttl_seconds
+    }
+}
+
+// implementation
+impl MomentoProxyConfig {
+    pub fn load(file: &str) -> Result<Self, std::io::Error> {
+        let mut file = std::fs::File::open(file)?;
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        match toml::from_str(&content) {
+            Ok(t) => Ok(t),
+            Err(e) => {
+                eprintln!("{e}");
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Error parsing config",
+                ))
+            }
+        }
+    }
+
+    pub fn caches(&self) -> &[Cache] {
+        &self.cache
+    }
+
+    pub fn threads(&self) -> Option<usize> {
+        self.proxy.threads
+    }
+}
+
+impl AdminConfig for MomentoProxyConfig {
+    fn admin(&self) -> &Admin {
+        &self.admin
+    }
+}
+
+impl DebugConfig for MomentoProxyConfig {
+    fn debug(&self) -> &Debug {
+        &self.debug
+    }
+}
+
+impl KlogConfig for MomentoProxyConfig {
+    fn klog(&self) -> &Klog {
+        &self.klog
+    }
+}

--- a/src/protocol/memcache/set.rs
+++ b/src/protocol/memcache/set.rs
@@ -12,6 +12,7 @@ pub async fn set(
     cache_name: &str,
     request: &Set,
     flags: bool,
+    memory_cache: Option<MCache>,
 ) -> Result<Response, Error> {
     SET.increment();
 
@@ -28,6 +29,11 @@ pub async fn set(
     } else {
         (*request.value()).to_owned()
     };
+
+    if let Some(memory_cache) = &memory_cache {
+        // TODO: This invalidates the cache entry, but we could probably just update it in place
+        memory_cache.delete(&key);
+    }
 
     BACKEND_REQUEST.increment();
 


### PR DESCRIPTION
Try to cache get value results for ttl_seconds. It's disabled by
default, but you can enable it per-cache in the configuration toml.

Currently I don't have an environment set up for testing this, so I'll chat with folks about it.