### PR TITLE
feat: add total active connection count as proxy metric

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,8 +1,10 @@
 use std::{
-    borrow::Borrow, mem::size_of, time::{Duration, Instant, SystemTime, UNIX_EPOCH}
+    borrow::Borrow,
+    mem::size_of,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use moka::{Expiry, sync::Cache};
+use moka::{sync::Cache, Expiry};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CacheValue {
@@ -78,11 +80,14 @@ impl MCache {
             .weigher(weigh)
             .expire_after(MCacheExpiry)
             .build();
-        Self { cache, ttl: std::cmp::min(ttl, Duration::from_secs(5 * 365 * 24 * 3600)) }
+        Self {
+            cache,
+            ttl: std::cmp::min(ttl, Duration::from_secs(5 * 365 * 24 * 3600)),
+        }
     }
 
     pub fn get<Q>(&self, key: &Q) -> Option<CacheEntry>
-    where 
+    where
         KeyType: Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
@@ -100,7 +105,7 @@ impl MCache {
     }
 
     pub fn delete<Q>(&self, key: &Q) -> Option<CacheValue>
-    where 
+    where
         KeyType: Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -285,14 +285,7 @@ async fn handle_memcache_request(
             let recorder = proxy_metrics.begin_memcached_get();
             with_rpc_call_guard(
                 recorder.clone(),
-                memcache::get(
-                    &mut client,
-                    &cache_name,
-                    r,
-                    flags,
-                    memory_cache,
-                    &recorder,
-                ),
+                memcache::get(&mut client, &cache_name, r, flags, memory_cache, &recorder),
             )
             .await
         }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -3,8 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::*;
-use momento_proxy::Protocol;
 use momento::CacheClientBuilder;
+use momento_proxy::Protocol;
 use pelikan_net::{TCP_ACCEPT, TCP_CLOSE, TCP_CONN_CURR};
 
 pub(crate) async fn listener(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,10 @@
 #[macro_use]
 extern crate logger;
 
-use cache::MCache;
 use ::config::{AdminConfig, TimeType};
 use backtrace::Backtrace;
+use cache::MCache;
 use clap::{Arg, Command};
-use momento_proxy::MomentoProxyConfig;
 use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::time::Duration;
@@ -17,6 +16,7 @@ use logger::configure_logging;
 use metriken::*;
 use momento::cache::{configurations, CollectionTtl};
 use momento::*;
+use momento_proxy::MomentoProxyConfig;
 use pelikan_net::{TCP_RECV_BYTE, TCP_SEND_BYTE};
 use protocol_admin::*;
 use session::*;

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -76,6 +76,8 @@ impl ProxyMetricsBuilder {
             memcached_unimplemented: RpcMetrics::new(gauge_factory, "memcached_unimplemented"),
             connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
             connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
+            total_active_connections: proxy_sum_gauge(gauge_factory, "total_active_connections"),
+            active_connections_counter: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         };
 
         Arc::new(metrics)

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -3,20 +3,13 @@ use goodmetrics::{
     downstream::{get_client, OpenTelemetryDownstream, OpentelemetryBatcher},
     pipeline::DimensionPosition,
 };
-use std::sync::{
-    atomic::{AtomicI64, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_rustls::rustls::RootCertStore;
 use tonic::metadata::MetadataValue;
 
-use super::{
-    proxy::DefaultProxyMetrics,
-    util::{proxy_statistic_set_gauge, proxy_sum_gauge},
-    RpcMetrics,
-};
+use super::proxy::DefaultProxyMetrics;
 
 pub struct ProxyMetricsBuilder {
     batch_interval: Duration,
@@ -76,31 +69,7 @@ impl ProxyMetricsBuilder {
             }
         }
 
-        // Keep track of the total number of active connections to the proxy
-        let total_active_connections_count = Arc::new(AtomicI64::new(0));
-        let total_active_connections =
-            proxy_statistic_set_gauge(gauge_factory, "total_active_connections");
-
-        // Emit the total active connections count every batch_interval seconds
-        let count_clone = total_active_connections_count.clone();
-        tokio::spawn(async move {
-            loop {
-                total_active_connections.observe(count_clone.load(Ordering::Relaxed));
-                tokio::time::sleep(self.batch_interval).await;
-            }
-        });
-
-        let metrics = DefaultProxyMetrics {
-            memcached_get: RpcMetrics::new(gauge_factory, "memcached_get"),
-            memcached_set: RpcMetrics::new(gauge_factory, "memcached_set"),
-            memcached_delete: RpcMetrics::new(gauge_factory, "memcached_delete"),
-            memcached_unimplemented: RpcMetrics::new(gauge_factory, "memcached_unimplemented"),
-            connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
-            connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
-            // Connections opening and closing should also update total_active_connections_count
-            total_active_connections_count,
-        };
-
+        let metrics = DefaultProxyMetrics::new(gauge_factory, self.batch_interval);
         Arc::new(metrics)
     }
 }

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -3,13 +3,20 @@ use goodmetrics::{
     downstream::{get_client, OpenTelemetryDownstream, OpentelemetryBatcher},
     pipeline::DimensionPosition,
 };
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_rustls::rustls::RootCertStore;
 use tonic::metadata::MetadataValue;
 
-use super::{proxy::DefaultProxyMetrics, util::proxy_sum_gauge, RpcMetrics};
+use super::{
+    proxy::DefaultProxyMetrics,
+    util::{proxy_statistic_set_gauge, proxy_sum_gauge},
+    RpcMetrics,
+};
 
 pub struct ProxyMetricsBuilder {
     batch_interval: Duration,
@@ -69,6 +76,20 @@ impl ProxyMetricsBuilder {
             }
         }
 
+        // Keep track of the total number of active connections to the proxy
+        let total_active_connections_count = Arc::new(AtomicI64::new(0));
+        let total_active_connections =
+            proxy_statistic_set_gauge(gauge_factory, "total_active_connections");
+
+        // Emit the total active connections count every batch_interval seconds
+        let count_clone = total_active_connections_count.clone();
+        tokio::spawn(async move {
+            loop {
+                total_active_connections.observe(count_clone.load(Ordering::Relaxed));
+                tokio::time::sleep(self.batch_interval).await;
+            }
+        });
+
         let metrics = DefaultProxyMetrics {
             memcached_get: RpcMetrics::new(gauge_factory, "memcached_get"),
             memcached_set: RpcMetrics::new(gauge_factory, "memcached_set"),
@@ -76,7 +97,8 @@ impl ProxyMetricsBuilder {
             memcached_unimplemented: RpcMetrics::new(gauge_factory, "memcached_unimplemented"),
             connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
             connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
-            total_active_connections: proxy_sum_gauge(gauge_factory, "total_active_connections"),
+            // Connections opening and closing should also update total_active_connections_count
+            total_active_connections_count,
         };
 
         Arc::new(metrics)

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -77,6 +77,7 @@ impl ProxyMetricsBuilder {
             connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
             connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
             total_active_connections: proxy_sum_gauge(gauge_factory, "total_active_connections"),
+            active_connections_counter: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         };
 
         Arc::new(metrics)

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -77,7 +77,6 @@ impl ProxyMetricsBuilder {
             connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
             connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
             total_active_connections: proxy_sum_gauge(gauge_factory, "total_active_connections"),
-            active_connections_counter: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         };
 
         Arc::new(metrics)

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -15,13 +15,18 @@ impl ConnectionGuard {
         connections_opened: SumHandle,
         connections_closed: SumHandle,
         total_active_connections: SumHandle,
+        active_connections_counter: Arc<AtomicI64>,
     ) -> Self {
         connections_opened.observe(1);
-        total_active_connections.observe(1);
+        let count = active_connections_counter.fetch_add(1, Ordering::Relaxed);
+        let current_count = count+1;
+        total_active_connections.observe(current_count as i64);
+        debug!("Incrementing total active connections: {}", current_count);
+
         Self {
             connections_closed,
             total_active_connections,
-            active_connections_counter: Arc::new(std::sync::atomic::AtomicI64::new(1)),
+            active_connections_counter,
         }
     }
 }
@@ -35,5 +40,6 @@ impl Drop for ConnectionGuard {
         let count = self.active_connections_counter.fetch_sub(1, Ordering::Relaxed);
         let current_count = count-1;
         self.total_active_connections.observe(current_count as i64);
+        debug!("Decrementing total active connections: {}", current_count);
     }
 }

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -1,11 +1,8 @@
-use std::sync::{atomic::{AtomicI64, Ordering}, Arc};
-
 use goodmetrics::SumHandle;
 
 pub struct ConnectionGuard {
     connections_closed: SumHandle,
     total_active_connections: SumHandle,
-    active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ConnectionGuard {
@@ -15,14 +12,12 @@ impl ConnectionGuard {
         connections_opened: SumHandle,
         connections_closed: SumHandle,
         total_active_connections: SumHandle,
-        active_connections_counter: Arc<AtomicI64>,
     ) -> Self {
         connections_opened.observe(1);
         total_active_connections.observe(1);
         Self {
             connections_closed,
             total_active_connections,
-            active_connections_counter,
         }
     }
 }

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -6,8 +6,6 @@ pub struct ConnectionGuard {
 }
 
 impl ConnectionGuard {
-    /// Creates a new `ConnectionGuard` instance and increments the `total_active_connections` counter.
-    /// Decrements the `total_active_connections` counter when the `ConnectionGuard` is dropped.
     pub fn new(
         connections_opened: SumHandle,
         connections_closed: SumHandle,

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -1,8 +1,11 @@
+use std::sync::{atomic::{AtomicI64, Ordering}, Arc};
+
 use goodmetrics::SumHandle;
 
 pub struct ConnectionGuard {
     connections_closed: SumHandle,
-    decrement_total_count_fn: Box<dyn Fn() + Send>,
+    total_active_connections: SumHandle,
+    active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ConnectionGuard {
@@ -11,12 +14,14 @@ impl ConnectionGuard {
     pub fn new(
         connections_opened: SumHandle,
         connections_closed: SumHandle,
-        decrement_total_count_fn: impl Fn() + 'static + Send,
+        total_active_connections: SumHandle,
     ) -> Self {
         connections_opened.observe(1);
+        total_active_connections.observe(1);
         Self {
             connections_closed,
-            decrement_total_count_fn: Box::new(decrement_total_count_fn),
+            total_active_connections,
+            active_connections_counter: Arc::new(std::sync::atomic::AtomicI64::new(1)),
         }
     }
 }
@@ -25,6 +30,10 @@ impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         // When the guard is dropped, we assume the connection is closed.
         self.connections_closed.observe(1);
-        (self.decrement_total_count_fn)();
+
+        // And decrement the number of total active connections
+        let count = self.active_connections_counter.fetch_sub(1, Ordering::Relaxed);
+        let current_count = count-1;
+        self.total_active_connections.observe(current_count as i64);
     }
 }

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -2,14 +2,24 @@ use goodmetrics::SumHandle;
 
 pub struct ConnectionGuard {
     connections_closed: SumHandle,
+    decrement_total_count_fn: Box<dyn Fn() + Send>,
 }
 
 impl ConnectionGuard {
     /// Creates a new `ConnectionGuard` instance.
-    /// This instance will increment the `connections_opened` counter
-    pub fn new(connections_opened: SumHandle, connections_closed: SumHandle) -> Self {
+    /// This instance will increment the `connections_opened` counter,
+    /// and it will increment the `connections_closed` counter and decrement
+    /// the `total_active_connections` counter when the guard is dropped.
+    pub fn new(
+        connections_opened: SumHandle,
+        connections_closed: SumHandle,
+        decrement_total_count_fn: impl Fn() + 'static + Send,
+    ) -> Self {
         connections_opened.observe(1);
-        Self { connections_closed }
+        Self {
+            connections_closed,
+            decrement_total_count_fn: Box::new(decrement_total_count_fn),
+        }
     }
 }
 
@@ -17,5 +27,6 @@ impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         // When the guard is dropped, we assume the connection is closed.
         self.connections_closed.observe(1);
+        (self.decrement_total_count_fn)();
     }
 }

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -1,21 +1,26 @@
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
+
 use goodmetrics::SumHandle;
 
 pub struct ConnectionGuard {
     connections_closed: SumHandle,
-    total_active_connections: SumHandle,
+    total_active_connections_count: Arc<AtomicI64>,
 }
 
 impl ConnectionGuard {
     pub fn new(
         connections_opened: SumHandle,
         connections_closed: SumHandle,
-        total_active_connections: SumHandle,
+        total_active_connections_count: Arc<AtomicI64>,
     ) -> Self {
         connections_opened.observe(1);
-        total_active_connections.observe(1);
+        total_active_connections_count.fetch_add(1, Ordering::Relaxed);
         Self {
             connections_closed,
-            total_active_connections,
+            total_active_connections_count,
         }
     }
 }
@@ -24,6 +29,7 @@ impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         // When the guard is dropped, we assume the connection is closed.
         self.connections_closed.observe(1);
-        self.total_active_connections.observe(-1);
+        self.total_active_connections_count
+            .fetch_sub(1, Ordering::Relaxed);
     }
 }

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -6,10 +6,8 @@ pub struct ConnectionGuard {
 }
 
 impl ConnectionGuard {
-    /// Creates a new `ConnectionGuard` instance.
-    /// This instance will increment the `connections_opened` counter,
-    /// and it will increment the `connections_closed` counter and decrement
-    /// the `total_active_connections` counter when the guard is dropped.
+    /// Creates a new `ConnectionGuard` instance and increments the `total_active_connections` counter.
+    /// Decrements the `total_active_connections` counter when the `ConnectionGuard` is dropped.
     pub fn new(
         connections_opened: SumHandle,
         connections_closed: SumHandle,

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -18,11 +18,7 @@ impl ConnectionGuard {
         active_connections_counter: Arc<AtomicI64>,
     ) -> Self {
         connections_opened.observe(1);
-        let count = active_connections_counter.fetch_add(1, Ordering::Relaxed);
-        let current_count = count+1;
-        total_active_connections.observe(current_count as i64);
-        debug!("Incrementing total active connections: {}", current_count);
-
+        total_active_connections.observe(1);
         Self {
             connections_closed,
             total_active_connections,
@@ -35,11 +31,6 @@ impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         // When the guard is dropped, we assume the connection is closed.
         self.connections_closed.observe(1);
-
-        // And decrement the number of total active connections
-        let count = self.active_connections_counter.fetch_sub(1, Ordering::Relaxed);
-        let current_count = count-1;
-        self.total_active_connections.observe(current_count as i64);
-        debug!("Decrementing total active connections: {}", current_count);
+        self.total_active_connections.observe(-1);
     }
 }

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,5 +1,4 @@
 use std::sync::{
-    atomic::{AtomicI64, Ordering},
     Arc,
 };
 
@@ -25,26 +24,14 @@ pub struct DefaultProxyMetrics {
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
     pub(crate) total_active_connections: SumHandle,
-    pub(crate) active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
     fn begin_connection(&self) -> ConnectionGuard {
-        let count = self
-            .active_connections_counter
-            .fetch_add(1, Ordering::Relaxed);
-        self.total_active_connections.observe(count as i64);
-        debug!("Incrementing active connections: {}", count+1);
-        let total_active_connections = self.total_active_connections.clone();
-        let active_connections_counter = self.active_connections_counter.clone();
         ConnectionGuard::new(
             self.connections_opened.clone(),
             self.connections_closed.clone(),
-            move || {
-                let count = active_connections_counter.fetch_sub(1, Ordering::Relaxed);
-                total_active_connections.observe(count as i64);
-                debug!("Decrementing active connections: {}", count+1);
-            },
+            self.total_active_connections.clone(),
         )
     }
 

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    atomic::AtomicI64, Arc
+    Arc
 };
 
 use super::ConnectionGuard;
@@ -24,7 +24,6 @@ pub struct DefaultProxyMetrics {
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
     pub(crate) total_active_connections: SumHandle,
-    pub(crate) active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
@@ -33,7 +32,6 @@ impl ProxyMetrics for DefaultProxyMetrics {
             self.connections_opened.clone(),
             self.connections_closed.clone(),
             self.total_active_connections.clone(),
-            self.active_connections_counter.clone(),
         )
     }
 

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    Arc,
+    atomic::AtomicI64, Arc
 };
 
 use super::ConnectionGuard;
@@ -24,6 +24,7 @@ pub struct DefaultProxyMetrics {
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
     pub(crate) total_active_connections: SumHandle,
+    pub(crate) active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
@@ -32,6 +33,7 @@ impl ProxyMetrics for DefaultProxyMetrics {
             self.connections_opened.clone(),
             self.connections_closed.clone(),
             self.total_active_connections.clone(),
+            self.active_connections_counter.clone(),
         )
     }
 

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -34,6 +34,7 @@ impl ProxyMetrics for DefaultProxyMetrics {
             .active_connections_counter
             .fetch_add(1, Ordering::Relaxed);
         self.total_active_connections.observe(count as i64);
+        debug!("Incrementing active connections: {}", count+1);
         let total_active_connections = self.total_active_connections.clone();
         let active_connections_counter = self.active_connections_counter.clone();
         ConnectionGuard::new(
@@ -42,6 +43,7 @@ impl ProxyMetrics for DefaultProxyMetrics {
             move || {
                 let count = active_connections_counter.fetch_sub(1, Ordering::Relaxed);
                 total_active_connections.observe(count as i64);
+                debug!("Decrementing active connections: {}", count+1);
             },
         )
     }

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,6 +1,4 @@
-use std::sync::{
-    Arc
-};
+use std::sync::{atomic::AtomicI64, Arc};
 
 use super::ConnectionGuard;
 use goodmetrics::SumHandle;
@@ -23,7 +21,7 @@ pub struct DefaultProxyMetrics {
     pub(crate) memcached_unimplemented: RpcMetrics,
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
-    pub(crate) total_active_connections: SumHandle,
+    pub(crate) total_active_connections_count: Arc<AtomicI64>,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
@@ -31,7 +29,7 @@ impl ProxyMetrics for DefaultProxyMetrics {
         ConnectionGuard::new(
             self.connections_opened.clone(),
             self.connections_closed.clone(),
-            self.total_active_connections.clone(),
+            self.total_active_connections_count.clone(),
         )
     }
 

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,7 +1,16 @@
-use std::sync::{atomic::AtomicI64, Arc};
+use std::{
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
-use super::ConnectionGuard;
-use goodmetrics::SumHandle;
+use super::{
+    util::{proxy_statistic_set_gauge, proxy_sum_gauge},
+    ConnectionGuard,
+};
+use goodmetrics::{GaugeFactory, SumHandle};
 
 use super::{RpcCallGuard, RpcMetrics};
 
@@ -22,6 +31,35 @@ pub struct DefaultProxyMetrics {
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
     pub(crate) total_active_connections_count: Arc<AtomicI64>,
+}
+
+impl DefaultProxyMetrics {
+    pub(crate) fn new(gauge_factory: &GaugeFactory, batch_interval: Duration) -> Self {
+        // Keep track of the total number of active connections to the proxy
+        let total_active_connections_count = Arc::new(AtomicI64::new(0));
+        let total_active_connections =
+            proxy_statistic_set_gauge(gauge_factory, "total_active_connections");
+
+        // Emit the total active connections count every batch_interval seconds
+        let count_clone = total_active_connections_count.clone();
+        tokio::spawn(async move {
+            loop {
+                total_active_connections.observe(count_clone.load(Ordering::Relaxed));
+                tokio::time::sleep(batch_interval).await;
+            }
+        });
+
+        // Create the remaining gauge handles
+        Self {
+            memcached_get: RpcMetrics::new(gauge_factory, "memcached_get"),
+            memcached_set: RpcMetrics::new(gauge_factory, "memcached_set"),
+            memcached_delete: RpcMetrics::new(gauge_factory, "memcached_delete"),
+            memcached_unimplemented: RpcMetrics::new(gauge_factory, "memcached_unimplemented"),
+            connections_opened: proxy_sum_gauge(gauge_factory, "connections_opened"),
+            connections_closed: proxy_sum_gauge(gauge_factory, "connections_closed"),
+            total_active_connections_count,
+        }
+    }
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
 
 use super::ConnectionGuard;
 use goodmetrics::SumHandle;
@@ -21,13 +24,25 @@ pub struct DefaultProxyMetrics {
     pub(crate) memcached_unimplemented: RpcMetrics,
     pub(crate) connections_opened: SumHandle,
     pub(crate) connections_closed: SumHandle,
+    pub(crate) total_active_connections: SumHandle,
+    pub(crate) active_connections_counter: Arc<AtomicI64>,
 }
 
 impl ProxyMetrics for DefaultProxyMetrics {
     fn begin_connection(&self) -> ConnectionGuard {
+        let count = self
+            .active_connections_counter
+            .fetch_add(1, Ordering::Relaxed);
+        self.total_active_connections.observe(count as i64);
+        let total_active_connections = self.total_active_connections.clone();
+        let active_connections_counter = self.active_connections_counter.clone();
         ConnectionGuard::new(
             self.connections_opened.clone(),
             self.connections_closed.clone(),
+            move || {
+                let count = active_connections_counter.fetch_sub(1, Ordering::Relaxed);
+                total_active_connections.observe(count as i64);
+            },
         )
     }
 

--- a/src/metrics/util.rs
+++ b/src/metrics/util.rs
@@ -1,7 +1,11 @@
-use goodmetrics::{GaugeDimensions, GaugeFactory, HistogramHandle, SumHandle};
+use goodmetrics::{GaugeDimensions, GaugeFactory, HistogramHandle, StatisticSetHandle, SumHandle};
 
 pub fn proxy_sum_gauge(g: &GaugeFactory, name: &'static str) -> SumHandle {
     g.dimensioned_gauge_sum("momento_proxy", name, Default::default())
+}
+
+pub fn proxy_statistic_set_gauge(g: &GaugeFactory, name: &'static str) -> StatisticSetHandle {
+    g.dimensioned_gauge_statistic_set("momento_proxy", name, Default::default())
 }
 
 fn proxy_request_latency_histogram(

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -32,24 +32,12 @@ pub async fn get(
                 }
                 None => {
                     BACKEND_REQUEST.increment();
-                    tasks.push_back(run_get(
-                        client,
-                        cache_name,
-                        flags,
-                        key,
-                        recorder
-                    ));
+                    tasks.push_back(run_get(client, cache_name, flags, key, recorder));
                 }
             }
         } else {
             BACKEND_REQUEST.increment();
-            tasks.push_back(run_get(
-                client,
-                cache_name,
-                flags,
-                key,
-                recorder
-            ));
+            tasks.push_back(run_get(client, cache_name, flags, key, recorder));
         }
     }
     let values_from_upstream: Vec<Option<protocol_memcache::Value>> = tasks.collect().await;


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1238

Adds a new `SumHandle` to keep track of the number of total active connections over time.

Completed end-to-end testing and verified the metric is showing up as expected in dashboard.