### PR TITLE
feat: add metrics for mcache and momento hit/miss latency

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -282,9 +282,24 @@ async fn handle_memcache_request(
             .await
         }
         memcache::Request::Get(ref r) => {
+            // Create closures to allow memcached::get() to record latency metrics for hit/miss responses
+            let recorder = proxy_metrics.begin_memcached_get();
+            let record_latency_miss_closure = || recorder.clone().complete_miss();
+            let record_latency_hit_mcache_closure = || recorder.clone().complete_hit_mcache();
+            let record_latency_hit_momento_closure = || recorder.clone().complete_hit_momento();
+
             with_rpc_call_guard(
-                proxy_metrics.begin_memcached_get(),
-                memcache::get(&mut client, &cache_name, r, flags, memory_cache),
+                recorder.clone(),
+                memcache::get(
+                    &mut client,
+                    &cache_name,
+                    r,
+                    flags,
+                    memory_cache,
+                    record_latency_miss_closure,
+                    record_latency_hit_mcache_closure,
+                    record_latency_hit_momento_closure,
+                ),
             )
             .await
         }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -282,12 +282,7 @@ async fn handle_memcache_request(
             .await
         }
         memcache::Request::Get(ref r) => {
-            // Create closures to allow memcached::get() to record latency metrics for hit/miss responses
             let recorder = proxy_metrics.begin_memcached_get();
-            let record_latency_miss_closure = || recorder.clone().complete_miss();
-            let record_latency_hit_mcache_closure = || recorder.clone().complete_hit_mcache();
-            let record_latency_hit_momento_closure = || recorder.clone().complete_hit_momento();
-
             with_rpc_call_guard(
                 recorder.clone(),
                 memcache::get(
@@ -296,9 +291,7 @@ async fn handle_memcache_request(
                     r,
                     flags,
                     memory_cache,
-                    record_latency_miss_closure,
-                    record_latency_hit_mcache_closure,
-                    record_latency_hit_momento_closure,
+                    &recorder,
                 ),
             )
             .await

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -1,60 +1,90 @@
 use std::{
     future::Future,
-    sync::atomic::{AtomicBool, Ordering}, time::Instant,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Instant,
 };
 
 use goodmetrics::{GaugeFactory, HistogramHandle};
 
 use super::util::{
-    proxy_request_latency_error_histogram, proxy_request_latency_ok_histogram,
+    proxy_request_latency_error_histogram, proxy_request_latency_hit_histogram,
+    proxy_request_latency_miss_histogram, proxy_request_latency_ok_histogram,
     proxy_request_latency_timeout_histogram,
 };
 
 #[derive(Clone, Debug)]
 pub struct RpcMetrics {
+    rpc: &'static str,
     latency_ok: HistogramHandle,
     latency_error: HistogramHandle,
     latency_timeout: HistogramHandle,
+    latency_miss: HistogramHandle,
+    latency_hit_mcache: HistogramHandle,
+    latency_hit_momento: HistogramHandle,
 }
 
 impl RpcMetrics {
     pub fn new(gauge_factory: &GaugeFactory, rpc: &'static str) -> Self {
         Self {
+            rpc,
             latency_ok: proxy_request_latency_ok_histogram(gauge_factory, rpc),
             latency_error: proxy_request_latency_error_histogram(gauge_factory, rpc),
             latency_timeout: proxy_request_latency_timeout_histogram(gauge_factory, rpc),
+            latency_miss: proxy_request_latency_miss_histogram(gauge_factory, rpc),
+            latency_hit_mcache: proxy_request_latency_hit_histogram(gauge_factory, rpc, "mcache"),
+            latency_hit_momento: proxy_request_latency_hit_histogram(gauge_factory, rpc, "momento"),
         }
     }
 
     pub fn record_api_call(&self) -> RpcCallGuard {
         RpcCallGuard::new(
+            self.rpc,
             self.latency_ok.clone(),
             self.latency_error.clone(),
             self.latency_timeout.clone(),
+            self.latency_miss.clone(),
+            self.latency_hit_mcache.clone(),
+            self.latency_hit_momento.clone(),
         )
     }
 }
 
+#[derive(Clone)]
 pub struct RpcCallGuard {
+    rpc: &'static str,
     start_time: Instant,
     latency_ok: HistogramHandle,
     latency_error: HistogramHandle,
     latency_timeout: HistogramHandle,
-    recorded: AtomicBool,
+    latency_miss: HistogramHandle,
+    latency_hit_mcache: HistogramHandle,
+    latency_hit_momento: HistogramHandle,
+    recorded: Arc<AtomicBool>,
 }
 
 impl RpcCallGuard {
     pub fn new(
+        rpc: &'static str,
         latency_ok: HistogramHandle,
         latency_error: HistogramHandle,
         latency_timeout: HistogramHandle,
+        latency_miss: HistogramHandle,
+        latency_hit_mcache: HistogramHandle,
+        latency_hit_momento: HistogramHandle,
     ) -> Self {
         Self {
+            rpc,
             start_time: Instant::now(),
             latency_ok,
             latency_error,
             latency_timeout,
-            recorded: AtomicBool::new(false),
+            latency_miss,
+            latency_hit_mcache,
+            latency_hit_momento,
+            recorded: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -63,6 +93,7 @@ impl RpcCallGuard {
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         {
+            debug!("{} complete_ok", self.rpc);
             self.latency_ok
                 .observe(self.start_time.elapsed().as_nanos() as i64);
         }
@@ -73,6 +104,7 @@ impl RpcCallGuard {
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         {
+            debug!("{} complete_error", self.rpc);
             self.latency_error
                 .observe(self.start_time.elapsed().as_nanos() as i64);
         }
@@ -84,6 +116,39 @@ impl RpcCallGuard {
             Err(_) => self.complete_error(),
         };
     }
+
+    pub fn complete_miss(&mut self) {
+        // Might observe multiple hits if multiple keys are requested, so update
+        // the recorded flag but don't check it before recording the latency.
+        debug!("{} complete_miss", self.rpc);
+        let _ = self
+            .recorded
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed);
+        self.latency_miss
+            .observe(self.start_time.elapsed().as_nanos() as i64);
+    }
+
+    pub fn complete_hit_mcache(&mut self) {
+        // Might observe multiple hits if multiple keys are requested, so update
+        // the recorded flag but don't check it before recording the latency.
+        debug!("{} complete_hit_mcache", self.rpc);
+        let _ = self
+            .recorded
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed);
+        self.latency_hit_mcache
+            .observe(self.start_time.elapsed().as_nanos() as i64);
+    }
+
+    pub fn complete_hit_momento(&mut self) {
+        // Might observe multiple hits if multiple keys are requested, so update
+        // the recorded flag but don't check it before recording the latency.
+        debug!("{} complete_hit_momento", self.rpc);
+        let _ = self
+            .recorded
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed);
+        self.latency_hit_momento
+            .observe(self.start_time.elapsed().as_nanos() as i64);
+    }
 }
 
 impl Drop for RpcCallGuard {
@@ -92,6 +157,7 @@ impl Drop for RpcCallGuard {
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         {
+            debug!("{} complete_timeout", self.rpc);
             self.latency_timeout
                 .observe(self.start_time.elapsed().as_nanos() as i64);
         }

--- a/src/metrics/util.rs
+++ b/src/metrics/util.rs
@@ -16,6 +16,34 @@ fn proxy_request_latency_histogram(
     )
 }
 
+fn proxy_hit_response_latency_histogram(
+    gauge_factory: &GaugeFactory,
+    rpc: &'static str,
+    result: &'static str,
+    source: &'static str, // momento or mcache
+) -> HistogramHandle {
+    gauge_factory.dimensioned_gauge_histogram(
+        "momento_proxy",
+        "latency",
+        GaugeDimensions::new([("rpc", rpc), ("result", result), ("source", source)]),
+    )
+}
+
+pub fn proxy_request_latency_hit_histogram(
+    g: &GaugeFactory,
+    rpc: &'static str,
+    source: &'static str,
+) -> HistogramHandle {
+    proxy_hit_response_latency_histogram(g, rpc, "hit", source)
+}
+
+pub fn proxy_request_latency_miss_histogram(
+    g: &GaugeFactory,
+    rpc: &'static str,
+) -> HistogramHandle {
+    proxy_request_latency_histogram(g, rpc, "miss")
+}
+
 pub fn proxy_request_latency_ok_histogram(g: &GaugeFactory, rpc: &'static str) -> HistogramHandle {
     proxy_request_latency_histogram(g, rpc, "ok")
 }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -81,7 +81,7 @@ async fn run_get(
     key: &[u8],
     recorder: &RpcCallGuard,
 ) -> Option<protocol_memcache::Value> {
-    let mut recorder_clone = recorder.clone();
+    let mut recorder = recorder.clone();
     match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
         Ok(Ok(response)) => match response {
             GetResponse::Hit { value } => {
@@ -90,7 +90,7 @@ async fn run_get(
                 let value: Vec<u8> = value.into();
 
                 if flags && value.len() < 5 {
-                    recorder_clone.complete_miss();
+                    recorder.complete_miss();
                     klog_1(&"get", &key, Status::Miss, 0);
                     None
                 } else if flags {
@@ -98,13 +98,13 @@ async fn run_get(
                     let value: Vec<u8> = value[4..].into();
                     let length = value.len();
 
-                    recorder_clone.complete_hit_momento();
+                    recorder.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, flags, None, &value))
                 } else {
                     let length = value.len();
 
-                    recorder_clone.complete_hit_momento();
+                    recorder.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, 0, None, &value))
                 }
@@ -112,7 +112,7 @@ async fn run_get(
             GetResponse::Miss => {
                 GET_KEY_MISS.increment();
 
-                recorder_clone.complete_miss();
+                recorder.complete_miss();
                 klog_1(&"get", &key, Status::Miss, 0);
                 None
             }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -15,12 +15,11 @@ pub async fn get(
     request: &Get,
     flags: bool,
     memory_cache: Option<MCache>,
-    latency_miss: impl Fn() + Clone,
-    latency_hit_mcache: impl Fn() + Clone,
-    latency_hit_momento: impl Fn() + Clone,
+    recorder: &RpcCallGuard,
 ) -> Result<Response, Error> {
     let mut tasks = futures::stream::FuturesOrdered::new();
     let mut eager_hits = Vec::new();
+    let mut recorder_clone = recorder.clone();
     for key in request.keys() {
         if let Some(memory_cache) = &memory_cache {
             match memory_cache.get(&**key) {
@@ -29,7 +28,7 @@ pub async fn get(
                         cache::CacheValue::Memcached { value } => value,
                     });
                     debug!("eager hit for key {:?}", key);
-                    latency_hit_mcache();
+                    recorder_clone.complete_hit_mcache();
                 }
                 None => {
                     BACKEND_REQUEST.increment();
@@ -38,8 +37,7 @@ pub async fn get(
                         cache_name,
                         flags,
                         key,
-                        latency_miss.clone(),
-                        latency_hit_momento.clone(),
+                        recorder
                     ));
                 }
             }
@@ -50,8 +48,7 @@ pub async fn get(
                 cache_name,
                 flags,
                 key,
-                latency_miss.clone(),
-                latency_hit_momento.clone(),
+                recorder
             ));
         }
     }
@@ -82,9 +79,9 @@ async fn run_get(
     cache_name: &str,
     flags: bool,
     key: &[u8],
-    latency_miss: impl Fn(),
-    latency_hit_momento: impl Fn(),
+    recorder: &RpcCallGuard,
 ) -> Option<protocol_memcache::Value> {
+    let mut recorder_clone = recorder.clone();
     match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
         Ok(Ok(response)) => match response {
             GetResponse::Hit { value } => {
@@ -93,7 +90,7 @@ async fn run_get(
                 let value: Vec<u8> = value.into();
 
                 if flags && value.len() < 5 {
-                    latency_miss();
+                    recorder_clone.complete_miss();
                     klog_1(&"get", &key, Status::Miss, 0);
                     None
                 } else if flags {
@@ -101,13 +98,13 @@ async fn run_get(
                     let value: Vec<u8> = value[4..].into();
                     let length = value.len();
 
-                    latency_hit_momento();
+                    recorder_clone.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, flags, None, &value))
                 } else {
                     let length = value.len();
 
-                    latency_hit_momento();
+                    recorder_clone.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, 0, None, &value))
                 }
@@ -115,7 +112,7 @@ async fn run_get(
             GetResponse::Miss => {
                 GET_KEY_MISS.increment();
 
-                latency_miss();
+                recorder_clone.complete_miss();
                 klog_1(&"get", &key, Status::Miss, 0);
                 None
             }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -15,30 +15,57 @@ pub async fn get(
     request: &Get,
     flags: bool,
     memory_cache: Option<MCache>,
+    latency_miss: impl Fn() + Clone,
+    latency_hit_mcache: impl Fn() + Clone,
+    latency_hit_momento: impl Fn() + Clone,
 ) -> Result<Response, Error> {
     let mut tasks = futures::stream::FuturesOrdered::new();
     let mut eager_hits = Vec::new();
     for key in request.keys() {
         if let Some(memory_cache) = &memory_cache {
             match memory_cache.get(&**key) {
-                Some(hit) => eager_hits.push(match hit.into_value() {
-                    cache::CacheValue::Memcached { value } => value,
-                }),
+                Some(hit) => {
+                    eager_hits.push(match hit.into_value() {
+                        cache::CacheValue::Memcached { value } => value,
+                    });
+                    debug!("eager hit for key {:?}", key);
+                    latency_hit_mcache();
+                }
                 None => {
                     BACKEND_REQUEST.increment();
-                    tasks.push_back(run_get(client, cache_name, flags, key));
+                    tasks.push_back(run_get(
+                        client,
+                        cache_name,
+                        flags,
+                        key,
+                        latency_miss.clone(),
+                        latency_hit_momento.clone(),
+                    ));
                 }
             }
         } else {
             BACKEND_REQUEST.increment();
-            tasks.push_back(run_get(client, cache_name, flags, key));
+            tasks.push_back(run_get(
+                client,
+                cache_name,
+                flags,
+                key,
+                latency_miss.clone(),
+                latency_hit_momento.clone(),
+            ));
         }
     }
     let values_from_upstream: Vec<Option<protocol_memcache::Value>> = tasks.collect().await;
-    let mut values: Vec<protocol_memcache::Value> = values_from_upstream.into_iter().flatten().collect();
+    let mut values: Vec<protocol_memcache::Value> =
+        values_from_upstream.into_iter().flatten().collect();
     if let Some(memory_cache) = &memory_cache {
         for value in values.iter() {
-            memory_cache.set(value.key().to_vec(), CacheValue::Memcached { value: value.clone() });
+            memory_cache.set(
+                value.key().to_vec(),
+                CacheValue::Memcached {
+                    value: value.clone(),
+                },
+            );
         }
     }
     values.extend(eager_hits);
@@ -55,8 +82,10 @@ async fn run_get(
     cache_name: &str,
     flags: bool,
     key: &[u8],
+    latency_miss: impl Fn(),
+    latency_hit_momento: impl Fn(),
 ) -> Option<protocol_memcache::Value> {
-    match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
+    match timeout(Duration::from_millis(500), client.get(cache_name, key)).await {
         Ok(Ok(response)) => match response {
             GetResponse::Hit { value } => {
                 GET_KEY_HIT.increment();
@@ -64,6 +93,7 @@ async fn run_get(
                 let value: Vec<u8> = value.into();
 
                 if flags && value.len() < 5 {
+                    latency_miss();
                     klog_1(&"get", &key, Status::Miss, 0);
                     None
                 } else if flags {
@@ -71,11 +101,13 @@ async fn run_get(
                     let value: Vec<u8> = value[4..].into();
                     let length = value.len();
 
+                    latency_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, flags, None, &value))
                 } else {
                     let length = value.len();
 
+                    latency_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Some(protocol_memcache::Value::new(key, 0, None, &value))
                 }
@@ -83,6 +115,7 @@ async fn run_get(
             GetResponse::Miss => {
                 GET_KEY_MISS.increment();
 
+                latency_miss();
                 klog_1(&"get", &key, Status::Miss, 0);
                 None
             }
@@ -99,7 +132,6 @@ async fn run_get(
         }
         Err(_) => {
             // we had a timeout, incr stats and move on
-            // treating it as a miss
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
 

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -85,7 +85,7 @@ async fn run_get(
     latency_miss: impl Fn(),
     latency_hit_momento: impl Fn(),
 ) -> Option<protocol_memcache::Value> {
-    match timeout(Duration::from_millis(500), client.get(cache_name, key)).await {
+    match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
         Ok(Ok(response)) => match response {
             GetResponse::Hit { value } => {
                 GET_KEY_HIT.increment();

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -19,7 +19,7 @@ pub async fn get(
 ) -> Result<Response, Error> {
     let mut tasks = futures::stream::FuturesOrdered::new();
     let mut eager_hits = Vec::new();
-    let mut recorder_clone = recorder.clone();
+    let mut mcache_recorder = recorder.clone();
     for key in request.keys() {
         if let Some(memory_cache) = &memory_cache {
             match memory_cache.get(&**key) {
@@ -28,7 +28,7 @@ pub async fn get(
                         cache::CacheValue::Memcached { value } => value,
                     });
                     debug!("eager hit for key {:?}", key);
-                    recorder_clone.complete_hit_mcache();
+                    mcache_recorder.complete_hit_mcache();
                 }
                 None => {
                     BACKEND_REQUEST.increment();


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1240

Created new `HistogramHandle` gauges for tracking `latency_miss`, `latency_hit_mcache`, and `latency_hit_momento`. The `memcache::get()` method is responsible for recording the latencies using the passed in `RpcCallGuard`.

Completed end-to-end testing and verified the new metrics appear on the dashboard.