### PR TITLE
ci: cache unchanged build layers

### DIFF
--- a/.github/workflows/momento-proxy-container-publish.yml
+++ b/.github/workflows/momento-proxy-container-publish.yml
@@ -37,3 +37,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: gomomento/momento-proxy:latest, gomomento/momento-proxy:${{ steps.semrel.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Uses GitHub Actions' cache to reuse unchanged layers, saving build
time.
