### PR TITLE
chore: log version at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // initialize logging
     let mut log = configure_logging(&config);
 
+    info!("starting momento-proxy v{}", env!("CARGO_PKG_VERSION"));
+
     // validate config parameters
     for cache in config.caches() {
         let name = cache.cache_name();


### PR DESCRIPTION
Logs the proxy binary version at proxy startup.
