### PR TITLE
ci: build linux musl

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -85,6 +85,10 @@ jobs:
             arch: amd64
           - target: aarch64-unknown-linux-gnu
             arch: arm64
+          - target: x86_64-unknown-linux-musl
+            arch: amd64-musl
+          - target: aarch64-unknown-linux-musl
+            arch: arm64-musl
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Build linux (musl) for EC2.

Release-As: 0.10.6