### PR TITLE
fix: use Ubuntu 22.04 runners because Ubuntu 24.04 built binaries do not run on AL2023

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -81,17 +81,17 @@ jobs:
       matrix:
         include:
           # Linux GNU
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             arch: amd64
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             arch: arm64
           # Linux MUSL
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             arch: amd64-musl
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             arch: arm64-musl
           # macOS

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -88,10 +88,10 @@ jobs:
             target: aarch64-unknown-linux-gnu
             arch: arm64
           # Linux MUSL
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             arch: amd64-musl
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             arch: arm64-musl
           # macOS


### PR DESCRIPTION
Github release binaries do not run on AL2023 because it doesn't support GLIBC 2.38
```
localhost bash[2932]: /opt/momento-proxy: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by /opt/momento-proxy)
```
Related issue: https://github.com/amazonlinux/amazon-linux-2023/issues/958