### PR TITLE
refactor: rename `MOMENTO_AUTHENTICATION` to `MOMENTO_API_KEY`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ precommit: clean-build lint
 # -----------------------------------------------------------
 
 check-env:
-	@if [ -z "${MOMENTO_AUTHENTICATION}" ]; then \
-		echo "MOMENTO_AUTHENTICATION is not set"; \
+	@if [ -z "${MOMENTO_API_KEY}" ]; then \
+		echo "MOMENTO_API_KEY is not set"; \
 		exit 1; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ Follow the [build steps](https://github.com/twitter/pelikan#building-pelikan) in
 
 ## Configuration
 
-### Authentication Token
+### API Key
 
-The Momento proxy requires that the `MOMENTO_AUTHENTICATION` environment
-variable is set and contains a valid Momento authentication token.
+The Momento proxy requires that the `MOMENTO_API_KEY` environment
+variable is set and contains a valid Momento API key.
 
 If you're new to Momento, you should refer to the
 [Momento CLI docs](https://github.com/momentohq/momento-cli#momento-cli) for
-instructions to sign up and get an authentication token.
+instructions to sign up and get an API key.
 
 ### Create Cache
 
-After obtaining an authentication token, you should create one or more caches to
+After obtaining an API key, you should create one or more caches to
 use with the proxy.
 
 ### Proxy Configuration
@@ -67,7 +67,7 @@ docker run -d \
   -p 11211:11211 \
   -p 6379:6379 \
   -p 9999:9999 \
-  -e MOMENTO_AUTHENTICATION=<YOUR_MOMENTO_TOKEN> \
+  -e MOMENTO_API_KEY=<YOUR_MOMENTO_API_KEY> \
   gomomento/momento-proxy
 ```
 
@@ -79,7 +79,7 @@ docker run -d \
   -p 11211:11211 \
   -p 6379:6379 \
   -p 9999:9999 \
-  -e MOMENTO_AUTHENTICATION=<YOUR_MOMENTO_TOKEN> \
+  -e MOMENTO_API_KEY=<YOUR_MOMENTO_API_KEY> \
   -e CONFIG=my_custom_config.toml \
   -v /your/path/to/config/dir:/app/config gomomento/momento-proxy
 ```
@@ -99,7 +99,7 @@ docker run -d \
   -p 11211:11211 \
   -p 6379:6379 \
   -p 9999:9999 \
-  -e MOMENTO_AUTHENTICATION=<YOUR_MOMENTO_TOKEN> \
+  -e MOMENTO_API_KEY=<YOUR_MOMENTO_API_KEY> \
   momento-proxy
 ```
 
@@ -110,7 +110,7 @@ docker run -d \
   -p 11211:11211 \
   -p 6379:6379 \
   -p 9999:9999 \
-  -e MOMENTO_AUTHENTICATION=<YOUR_MOMENTO_TOKEN> \
+  -e MOMENTO_API_KEY=<YOUR_MOMENTO_API_KEY> \
   -e CONFIG=<YOUR_CONFIG_FILE> \
   -v /your/path/to/config/dir:/app/config \
   momento-proxy
@@ -129,6 +129,7 @@ STORED
 ```
 
 - Or you can use `redis-cli` to test to see if `momento-proxy` is running properly for Redis:
+
 ```
 redis-cli -h 0.0.0.0 -p 6379 SET FOO BAR
 OK

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ pub use metrics::*;
 // The following environment variables are necessary to configure the proxy
 // until the config file is finalized:
 //
-// MOMENTO_AUTHENTICATION - the Momento authentication token
+// MOMENTO_API_KEY - the Momento API key to use for authentication
 
 // Default for linux, should work well enough for the majority of platforms.
 pub const PAGESIZE: usize = 4096;
@@ -253,16 +253,16 @@ async fn spawn(
     info!("starting proxy admin listener on: {}", admin_addr);
 
     // initialize the Momento cache client
-    if std::env::var("MOMENTO_AUTHENTICATION").is_err() {
-        eprintln!("environment variable `MOMENTO_AUTHENTICATION` is not set");
+    if std::env::var("MOMENTO_API_KEY").is_err() {
+        eprintln!("environment variable `MOMENTO_API_KEY` is not set");
         std::process::exit(1);
     }
-    let auth_token =
-        std::env::var("MOMENTO_AUTHENTICATION").expect("MOMENTO_AUTHENTICATION must be set");
-    let credential_provider = CredentialProvider::from_string(auth_token).unwrap_or_else(|e| {
-        eprintln!("failed to initialize credential provider. error: {e}");
-        std::process::exit(1);
-    });
+    let momento_api_key = std::env::var("MOMENTO_API_KEY").expect("MOMENTO_API_KEY must be set");
+    let credential_provider =
+        CredentialProvider::from_string(momento_api_key).unwrap_or_else(|e| {
+            eprintln!("failed to initialize credential provider. error: {e}");
+            std::process::exit(1);
+        });
 
     if config.caches().is_empty() {
         eprintln!("no caches specified in the config");


### PR DESCRIPTION
Prefer the standard `MOMENTO_API_KEY` env var to the previous
`MOMENTO_AUTNENTICATION`.
