### PR TITLE
fix: memcached proxy error results from momento were getting reported as ok

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -87,4 +87,7 @@ pub use connection::ConnectionGuard;
 pub use proxy::{
     ConnectionMetrics, DefaultProxyMetrics, MemcachedMetrics, ProxyMetrics, RespMetrics,
 };
-pub use rpc::{with_rpc_call_guard, RpcCallGuard, RpcMetrics};
+pub use rpc::{
+    with_rpc_call_guard, with_wrapped_error_response_rpc_call_guard, ResponseWrappingError,
+    RpcCallGuard, RpcMetrics,
+};

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -89,7 +89,6 @@ impl RpcCallGuard {
     }
 
     pub fn complete_ok(&mut self) {
-        debug!("{} complete_ok", self.rpc);
         if let Ok(false) =
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
@@ -100,7 +99,6 @@ impl RpcCallGuard {
     }
 
     pub fn complete_error(&mut self) {
-        error!("{} complete_error", self.rpc);
         if let Ok(false) =
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -89,22 +89,22 @@ impl RpcCallGuard {
     }
 
     pub fn complete_ok(&mut self) {
+        debug!("{} complete_ok", self.rpc);
         if let Ok(false) =
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         {
-            debug!("{} complete_ok", self.rpc);
             self.latency_ok
                 .observe(self.start_time.elapsed().as_nanos() as i64);
         }
     }
 
     pub fn complete_error(&mut self) {
+        error!("{} complete_error", self.rpc);
         if let Ok(false) =
             self.recorded
                 .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
         {
-            debug!("{} complete_error", self.rpc);
             self.latency_error
                 .observe(self.start_time.elapsed().as_nanos() as i64);
         }

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -172,3 +172,30 @@ where
     recorder.complete(&result);
     result
 }
+
+pub trait ResponseWrappingError {
+    fn is_error(&self) -> bool;
+}
+
+pub async fn with_wrapped_error_response_rpc_call_guard<R: ResponseWrappingError, E, F>(
+    mut recorder: RpcCallGuard,
+    fut: F,
+) -> Result<R, E>
+where
+    F: Future<Output = Result<R, E>>,
+{
+    let result = fut.await;
+    match &result {
+        Ok(response) => {
+            if response.is_error() {
+                recorder.complete_error();
+            } else {
+                recorder.complete_ok();
+            }
+        }
+        Err(_) => {
+            recorder.complete_error();
+        }
+    }
+    result
+}

--- a/src/protocol/memcache/delete.rs
+++ b/src/protocol/memcache/delete.rs
@@ -48,6 +48,7 @@ pub async fn delete(
             }
         }
         Ok(Err(e)) => {
+            error!("backend error for delete: {}", e);
             BACKEND_EX.increment();
 
             DELETE_EX.increment();
@@ -55,9 +56,10 @@ pub async fn delete(
 
             klog_1(&"delete", &key, Status::ServerError, 0);
 
-            Ok(Response::server_error(format!("{e}")))
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
-        Err(_) => {
+        Err(e) => {
+            error!("backend timeout for delete: {}", e);
             // timeout
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
@@ -67,7 +69,7 @@ pub async fn delete(
 
             klog_1(&"delete", &key, Status::Timeout, 0);
 
-            Ok(Response::server_error("backend timeout"))
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
     }
 }

--- a/src/protocol/memcache/delete.rs
+++ b/src/protocol/memcache/delete.rs
@@ -48,7 +48,6 @@ pub async fn delete(
             }
         }
         Ok(Err(e)) => {
-            error!("backend error for delete: {}", e);
             BACKEND_EX.increment();
 
             DELETE_EX.increment();
@@ -56,10 +55,10 @@ pub async fn delete(
 
             klog_1(&"delete", &key, Status::ServerError, 0);
 
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            error!("backend error for delete: {}", e);
+            Ok(Response::server_error(format!("{e}")))
         }
-        Err(e) => {
-            error!("backend timeout for delete: {}", e);
+        Err(_) => {
             // timeout
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
@@ -69,7 +68,8 @@ pub async fn delete(
 
             klog_1(&"delete", &key, Status::Timeout, 0);
 
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            error!("backend timeout for delete");
+            Ok(Response::server_error("backend timeout"))
         }
     }
 }

--- a/src/protocol/memcache/delete.rs
+++ b/src/protocol/memcache/delete.rs
@@ -68,7 +68,6 @@ pub async fn delete(
 
             klog_1(&"delete", &key, Status::Timeout, 0);
 
-            error!("backend timeout for delete");
             Ok(Response::server_error("backend timeout"))
         }
     }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -127,8 +127,6 @@ async fn run_get(
             Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
         Err(_) => {
-            error!("backend timeout for get");
-
             // we had a timeout, incr stats and move on
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -49,7 +49,7 @@ pub async fn get(
         if let Ok(Some(v)) = value {
             values.push(v);
         } else if let Err(e) = value {
-            return Err(Error::new(ErrorKind::Other, format!("{e}")));
+            return Ok(Response::server_error(format!("{e}")));
         }
     }
     if let Some(memory_cache) = &memory_cache {
@@ -126,14 +126,15 @@ async fn run_get(
             klog_1(&"get", &key, Status::ServerError, 0);
             Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
-        Err(e) => {
-            error!("backend timeout for get: {}", e);
+        Err(_) => {
+            error!("backend timeout for get");
+
             // we had a timeout, incr stats and move on
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
 
             klog_1(&"get", &key, Status::Timeout, 0);
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            Err(Error::new(ErrorKind::Other, format!("backend timeout")))
         }
     }
 }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -40,9 +40,18 @@ pub async fn get(
             tasks.push_back(run_get(client, cache_name, flags, key, recorder));
         }
     }
-    let values_from_upstream: Vec<Option<protocol_memcache::Value>> = tasks.collect().await;
-    let mut values: Vec<protocol_memcache::Value> =
-        values_from_upstream.into_iter().flatten().collect();
+
+    // If we had received an auth or timeout error, we should return the error immediately
+    let values_from_upstream: Vec<Result<Option<protocol_memcache::Value>, Error>> =
+        tasks.collect().await;
+    let mut values: Vec<protocol_memcache::Value> = Vec::new();
+    for value in values_from_upstream.into_iter() {
+        if let Ok(Some(v)) = value {
+            values.push(v);
+        } else if let Err(e) = value {
+            return Err(Error::new(ErrorKind::Other, format!("{e}")));
+        }
+    }
     if let Some(memory_cache) = &memory_cache {
         for value in values.iter() {
             memory_cache.set(
@@ -68,7 +77,7 @@ async fn run_get(
     flags: bool,
     key: &[u8],
     recorder: &RpcCallGuard,
-) -> Option<protocol_memcache::Value> {
+) -> Result<Option<protocol_memcache::Value>, Error> {
     let mut recorder = recorder.clone();
     match timeout(Duration::from_millis(200), client.get(cache_name, key)).await {
         Ok(Ok(response)) => match response {
@@ -80,7 +89,7 @@ async fn run_get(
                 if flags && value.len() < 5 {
                     recorder.complete_miss();
                     klog_1(&"get", &key, Status::Miss, 0);
-                    None
+                    Ok(None)
                 } else if flags {
                     let flags: u32 = u32::from_be_bytes([value[0], value[1], value[2], value[3]]);
                     let value: Vec<u8> = value[4..].into();
@@ -88,13 +97,15 @@ async fn run_get(
 
                     recorder.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
-                    Some(protocol_memcache::Value::new(key, flags, None, &value))
+                    Ok(Some(protocol_memcache::Value::new(
+                        key, flags, None, &value,
+                    )))
                 } else {
                     let length = value.len();
 
                     recorder.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
-                    Some(protocol_memcache::Value::new(key, 0, None, &value))
+                    Ok(Some(protocol_memcache::Value::new(key, 0, None, &value)))
                 }
             }
             GetResponse::Miss => {
@@ -102,7 +113,7 @@ async fn run_get(
 
                 recorder.complete_miss();
                 klog_1(&"get", &key, Status::Miss, 0);
-                None
+                Ok(None)
             }
         },
         Ok(Err(e)) => {
@@ -113,15 +124,16 @@ async fn run_get(
             BACKEND_EX.increment();
 
             klog_1(&"get", &key, Status::ServerError, 0);
-            None
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
-        Err(_) => {
+        Err(e) => {
+            error!("backend timeout for get: {}", e);
             // we had a timeout, incr stats and move on
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
 
             klog_1(&"get", &key, Status::Timeout, 0);
-            None
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
     }
 }

--- a/src/protocol/memcache/set.rs
+++ b/src/protocol/memcache/set.rs
@@ -88,7 +88,6 @@ pub async fn set(
             }
         }
         Ok(Err(e)) => {
-            error!("Set request backend error: {:?}", e);
             BACKEND_EX.increment();
 
             SET_EX.increment();
@@ -103,10 +102,10 @@ pub async fn set(
                 0,
             );
 
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            error!("backend error for set: {}", e);
+            Ok(Response::server_error(format!("{e}")))
         }
-        Err(e) => {
-            error!("Set request backend timeout: {:?}", e);
+        Err(_) => {
             // timeout
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
@@ -123,7 +122,8 @@ pub async fn set(
                 0,
             );
 
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            error!("Set request backend timeout");
+            Ok(Response::server_error("backend timeout"))
         }
     }
 }

--- a/src/protocol/memcache/set.rs
+++ b/src/protocol/memcache/set.rs
@@ -122,7 +122,6 @@ pub async fn set(
                 0,
             );
 
-            error!("Set request backend timeout");
             Ok(Response::server_error("backend timeout"))
         }
     }

--- a/src/protocol/memcache/set.rs
+++ b/src/protocol/memcache/set.rs
@@ -88,6 +88,7 @@ pub async fn set(
             }
         }
         Ok(Err(e)) => {
+            error!("Set request backend error: {:?}", e);
             BACKEND_EX.increment();
 
             SET_EX.increment();
@@ -102,9 +103,10 @@ pub async fn set(
                 0,
             );
 
-            Ok(Response::server_error(format!("{e}")))
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
-        Err(_) => {
+        Err(e) => {
+            error!("Set request backend timeout: {:?}", e);
             // timeout
             BACKEND_EX.increment();
             BACKEND_EX_TIMEOUT.increment();
@@ -121,7 +123,7 @@ pub async fn set(
                 0,
             );
 
-            Ok(Response::server_error("backend timeout"))
+            Err(Error::new(ErrorKind::Other, format!("{e}")))
         }
     }
 }


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1249

Memcached proxy was returning errors from momento (such as auth error from using expired api key) back to rpc guard as Ok, thus showing up in chronosphere as 'ok' or 'timeout' results and never as 'error' as expected