### PR TITLE
chore: klog should output json objects in log lines

### DIFF
--- a/src/klog.rs
+++ b/src/klog.rs
@@ -27,7 +27,7 @@ pub(crate) fn klog_1(
     response_len: usize,
 ) {
     klog!(
-        "\"{} {}\" {} {}",
+        "{{\"command\": \"{}\", \"key\": \"{}\", \"response_status\": \"{}\", \"response_size\": \"{}\"}}",
         command,
         EscapedStr::new(key),
         status as u8,
@@ -43,7 +43,7 @@ pub(crate) fn klog_2(
     response_len: usize,
 ) {
     klog!(
-        "\"{} {} {}\" {} {}",
+        "{{\"command\": \"{}\", \"key\": \"{}\", \"field\": \"{}\", \"response_status\": \"{}\", \"response_size\": \"{}\"}}",
         command,
         EscapedStr::new(key),
         EscapedStr::new(field),
@@ -62,7 +62,7 @@ pub(crate) fn klog_7(
     response_len: usize,
 ) {
     klog!(
-        "\"{} {} {} {} {}\" {} {}",
+        "{{\"command\": \"{}\", \"key\": \"{}\", \"field\": \"{}\", \"ttl\": \"{}\", \"request_size\": \"{}\", \"response_status\": \"{}\", \"response_size\": \"{}\"}}",
         command,
         EscapedStr::new(key),
         EscapedStr::new(field),
@@ -82,7 +82,7 @@ pub fn klog_set(
     response_len: usize,
 ) {
     klog!(
-        "\"set {} {} {} {}\" {} {}",
+        "{{\"command\": \"set\", \"key\": \"{}\", \"flags\": \"{}\", \"ttl\": \"{}\", \"request_size\": \"{}\", \"response_status\": \"{}\", \"response_size\": \"{}\"}}",
         EscapedStr::new(key),
         flags,
         ttl,


### PR DESCRIPTION
Trying to make the klog output file more easily parseable

Sample log output before:

```
2025-07-08T17:04:36.656+00:00 "set foo 0 0 7" 5 7
2025-07-08T17:04:38.468+00:00 "get foo" 4 3
2025-07-08T17:04:40.545+00:00 "delete foo" 7 0
```

Sample log output after:

```
2025-07-08T18:17:12.169+00:00 {"command": "set", "key": "abc", "flags": "0", "ttl": "0", "request_size": "7", "response_status": "5", "response_size": "7"}
2025-07-08T18:17:18.684+00:00 {"command": "get", "key": "abc", "response_status": "4", "response_size": "3"}
2025-07-08T18:17:32.758+00:00 {"command": "delete", "key": "abc", "response_status": "7", "response_size": "0"}
```