### PR TITLE
fix: re-enable lint PR check and fix lint errors

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,19 +9,19 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  #  rustfmt:
-  #    name: main - Style & Lint
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - uses: actions/checkout@v3
-  #
-  #      - name: Commitlint and Other Shared Build Steps
-  #        uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
-  #
-  #      - uses: Swatinem/rust-cache@v2
-  #
-  #      - name: Lint (rustfmt and clippy)
-  #        run: make lint
+  rustfmt:
+    name: main - Style & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Commitlint and Other Shared Build Steps
+        uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Lint (rustfmt and clippy)
+        run: make lint
 
   build_rust:
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,28 +96,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +104,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -165,71 +153,26 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.2",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
+ "sync_wrapper",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -242,13 +185,13 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -270,12 +213,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -286,7 +223,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -297,7 +234,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
  "which",
@@ -309,23 +246,17 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -339,7 +270,7 @@ version = "4.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd4d65a24a5e58e9b820723e496bfa920dd0afd31676646c81cfc3b6f34e039"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "boring-sys",
  "foreign-types",
  "libc",
@@ -369,6 +300,12 @@ dependencies = [
  "regex-automata 0.4.9",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -401,6 +338,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clang-sys"
@@ -493,18 +436,11 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
- "core-foundation-sys",
- "libc",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -558,14 +494,35 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -641,6 +598,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -785,8 +751,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -796,9 +764,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -823,37 +793,18 @@ dependencies = [
  "exponential-histogram",
  "futures",
  "futures-batch",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "log",
  "ordered-float",
- "prost 0.13.5",
+ "prost",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tokio-stream",
- "tonic 0.13.1",
- "tower 0.5.2",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.9.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "tonic",
+ "tower",
 ]
 
 [[package]]
@@ -867,19 +818,13 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.9.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -893,7 +838,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95aebe0dec9a429e3207e5e34d97f2a7d1064d5ee6d8ed13ce0a26456de000ae"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -903,17 +848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -929,23 +863,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -956,8 +879,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -975,30 +898,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -1006,9 +905,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1025,28 +924,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.3.1",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.27",
- "rustls-native-certs 0.8.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1055,7 +942,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1071,25 +958,117 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.3"
+name = "icu_collections"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1099,8 +1078,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1140,6 +1125,28 @@ checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
  "getrandom 0.3.2",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "k-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab228fb4852ec5d997306dc0d652235b0de0595dc1f0a7a2bd96b03730b96474"
+dependencies = [
+ "atomic-wait",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -1197,6 +1204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,12 +1262,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1357,39 +1370,48 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "momento"
-version = "0.52.0"
+version = "0.64.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5b89db548d8d900d2a62737b090e61f9263cb9a7c1b841b697c3b83b9f52dc"
+checksum = "063bc6e656658e521debc680eee56811128c0152812fea838545f028101816f2"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "derive_more",
  "futures",
- "h2 0.3.26",
- "hyper 0.14.32",
+ "h2",
+ "http",
+ "hyper",
  "log",
  "momento-protos",
- "rand",
+ "protosocket",
+ "protosocket-prost",
+ "protosocket-rpc",
+ "rand 0.9.4",
+ "reqwest",
+ "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror",
- "tonic 0.10.2",
+ "temp-env",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
  "zstd",
 ]
 
 [[package]]
 name = "momento-protos"
-version = "0.125.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96944394b533d483b4adc7fb79568d49954d434966c02dc9f5ad65ae52ae904a"
+checksum = "e522903f13088da517d053096450fdd8073f889674e0490ba479118607f88282"
 dependencies = [
- "prost 0.12.6",
- "tonic 0.10.2",
+ "prost",
+ "protosocket-rpc",
+ "tonic",
 ]
 
 [[package]]
@@ -1417,11 +1439,11 @@ dependencies = [
  "serde",
  "session",
  "storage-types",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "toml",
- "tonic 0.13.1",
+ "tonic",
  "webpki-roots 1.0.0",
 ]
 
@@ -1573,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1643,6 +1665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,35 +1718,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1783,7 +1791,110 @@ dependencies = [
  "metriken",
  "nom",
  "protocol-common",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protosocket"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d1f11b21e33dea20b9fd42f0832cdb13ab98f6fbf83bb38260027747f55dc5"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "protosocket-prost"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3061ed45eea92f668ff46639a2b7b71c948a368c49f92a965b4b1e12b95a527b"
+dependencies = [
+ "bytes",
+ "log",
+ "prost",
+ "protosocket",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "protosocket-rpc"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c39ac0bf30b8488a4d72a8d19d9c91214b2648883357f460b5ecd373e2e6f4"
+dependencies = [
+ "futures",
+ "k-lock",
+ "log",
+ "protosocket",
+ "rand 0.9.4",
+ "rustls-pki-types",
+ "socket2 0.6.3",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.5.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.2",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.9",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1807,19 +1918,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1827,9 +1946,21 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "redox_syscall"
@@ -1837,7 +1968,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1885,6 +2016,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +2099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,23 +2119,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -1966,22 +2135,11 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -1993,16 +2151,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.21.7",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2011,17 +2169,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2070,36 +2219,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2159,6 +2285,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2232,6 +2370,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "storage-types"
 version = "0.3.2"
 source = "git+https://github.com/pelikan-io/pelikan.git?rev=4afdd11#4afdd11ab9e37244789993d5066cd4a6382913f3"
@@ -2261,15 +2415,23 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tagptr"
@@ -2278,12 +2440,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2291,6 +2471,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,6 +2530,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,19 +2567,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -2379,21 +2585,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.27",
+ "rustls",
  "tokio",
 ]
 
@@ -2448,7 +2644,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2464,84 +2660,33 @@ checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum 0.8.4",
- "base64 0.22.1",
+ "axum",
+ "base64",
  "bytes",
- "h2 0.4.10",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout 0.5.2",
+ "hyper",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "socket2",
+ "prost",
+ "socket2 0.5.9",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2552,10 +2697,10 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.9.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -2649,10 +2794,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2706,10 +2880,88 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.25.4"
+name = "wasm-bindgen"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -2763,7 +3015,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-numerics",
 ]
 
@@ -2784,9 +3036,9 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2796,7 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-threading",
 ]
 
@@ -2829,13 +3081,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2844,7 +3113,16 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -2853,7 +3131,22 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2884,6 +3177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,11 +3209,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2920,8 +3239,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2936,6 +3261,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,6 +3283,18 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2960,10 +3309,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2978,6 +3345,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3367,18 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3002,6 +3393,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3415,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3028,7 +3437,36 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -3052,27 +3490,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zstd"
-version = "0.12.4"
+name = "zerotrie"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.6"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2.149"
 logger = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "logger" }
 metriken = "0.7.0"
 moka = { version = "0.12", features = ["sync"] }
-momento = "0.52.0"
+momento = "0.64.2"
 pelikan-net = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "pelikan-net", features = ["metrics"] }
 protocol-admin = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "protocol-admin" }
 protocol-memcache = { git = "https://github.com/pelikan-io/pelikan.git", rev = "4afdd11", package = "protocol-memcache" }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Momento Proxy
 
 This product is a simple proxy which can allow existing applications which use
-Memcached set/get operations for caching to use [Momento](https://momentohq.com)
+Memcached or RESP operations for caching to use [Momento](https://momentohq.com)
 cache offering without any code changes.
 
 ## Features
 
-- **Transparent**: allows existing applications which use Memcached to switch to
+- **Transparent**: allows existing applications which use Memcached or RESP to switch to
   Momento without code changes.
 - **Stats**: get insight into runtime by using the Memcached `stats` command on
   the admin port.
@@ -15,22 +15,20 @@ cache offering without any code changes.
 
 ## Limitations
 
-- Only `get` and `set` operations are supported.
+- Only Memcached `get`, `set`, and `delete` operations are supported.
+- Only a subset of RESP operations are supported; see the [protocol/resp](./src/protocol/resp/) folder.
 
 ## Building
 
-Follow the [build steps](https://github.com/twitter/pelikan#building-pelikan) in the readme.
+Use the [Makefile](./Makefile).
 
 ## Configuration
 
 ### API Key
 
 The Momento proxy requires that the `MOMENTO_API_KEY` environment
-variable is set and contains a valid Momento API key.
-
-If you're new to Momento, you should refer to the
-[Momento CLI docs](https://github.com/momentohq/momento-cli#momento-cli) for
-instructions to sign up and get an API key.
+variable is set and contains a valid Momento API key, which you can 
+obtain from the [Momento Console](https://console.gomomento.com/).
 
 ### Create Cache
 
@@ -41,7 +39,7 @@ use with the proxy.
 
 The Momento proxy uses a TOML configuration file. As there aren't any sensible
 defaults, we require that you provide a configuration file when using the proxy.
-See the [example config](https://github.com/twitter/pelikan/blob/master/config/momento_proxy.toml) and modify it to suit
+See the [example config](./config/momento_proxy.toml) and modify it to suit
 your requirements.
 
 ## Running
@@ -71,7 +69,7 @@ docker run -d \
   gomomento/momento-proxy
 ```
 
-By default, [this configuration](https://github.com/twitter/pelikan/blob/master/config/momento_proxy.toml) is used for the Momento proxy.
+By default, [this configuration](./config/momento_proxy.toml) is used for the Momento proxy.
 To set your own, please provide an env variable `CONFIG` as well as the directory where your config file is located to `-v` when running a container.
 
 ```

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -91,7 +91,7 @@ impl MCache {
         KeyType: Borrow<Q>,
         Q: std::hash::Hash + Eq + ?Sized,
     {
-        self.cache.get(&key)
+        self.cache.get(key)
     }
 
     pub fn set(&self, key: KeyType, value: impl Into<CacheValue>) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub type ProxyResult<T = ()> = Result<T, ProxyError>;
 #[derive(Debug, Error)]
 pub enum ProxyError {
     #[error("momento error: {0}")]
-    Momento(#[source] MomentoError),
+    Momento(#[source] Box<MomentoError>),
     #[error("io error: {0}")]
     Io(#[source] std::io::Error),
     #[error("timeout: {0}")]
@@ -31,7 +31,7 @@ impl ProxyError {
 
 impl From<MomentoError> for ProxyError {
     fn from(value: MomentoError) -> Self {
-        ProxyError::Momento(value)
+        ProxyError::Momento(Box::new(value))
     }
 }
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -77,6 +77,7 @@ pub(crate) async fn handle_memcache_client(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_memcache_client_concrete(
     socket: tokio::net::TcpStream,
     client: CacheClient,
@@ -264,15 +265,16 @@ pub(crate) async fn handle_memcache_client_concrete(
 // response is actually an error.
 impl ResponseWrappingError for protocol_memcache::Response {
     fn is_error(&self) -> bool {
-        match self {
-            protocol_memcache::Response::ServerError(_) => true,
-            protocol_memcache::Response::ClientError(_) => true,
-            protocol_memcache::Response::Error(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            protocol_memcache::Response::ServerError(_)
+                | protocol_memcache::Response::ClientError(_)
+                | protocol_memcache::Response::Error(_)
+        )
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_memcache_request(
     channel: mpsc::Sender<
         std::result::Result<
@@ -303,7 +305,7 @@ async fn handle_memcache_request(
             let recorder = proxy_metrics.begin_memcached_get();
             with_wrapped_error_response_rpc_call_guard(
                 recorder.clone(),
-                memcache::get(&mut client, &cache_name, r, flags, memory_cache, &recorder),
+                memcache::get(&client, &cache_name, r, flags, memory_cache, &recorder),
             )
             .await
         }
@@ -317,7 +319,7 @@ async fn handle_memcache_request(
         _ => {
             debug!("unsupported command: {}", request);
             with_rpc_call_guard(proxy_metrics.begin_memcached_unimplemented(), async {
-                Err(Error::new(ErrorKind::Other, "unsupported"))
+                Err(Error::other("unsupported"))
             })
             .await
         }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -693,7 +693,7 @@ pub(crate) async fn handle_resp_client(
                         crate::protocol::resp::momento_error_to_resp_error(
                             &mut response_buf,
                             command,
-                            error,
+                            *error,
                         );
 
                         false

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -7,6 +7,7 @@ use momento::CacheClientBuilder;
 use momento_proxy::Protocol;
 use pelikan_net::{TCP_ACCEPT, TCP_CLOSE, TCP_CONN_CURR};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn listener(
     listener: TcpListener,
     client_builder: CacheClientBuilder<ReadyToBuild>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+//! Momento proxy: translates Memcache/RESP protocol requests to Momento gRPC.
+
 #[macro_use]
 extern crate logger;
 
@@ -31,7 +33,9 @@ use tokio::time::timeout;
 
 use crate::error::{ProxyError, ProxyResult};
 
+/// One kilobyte in bytes.
 pub const KB: usize = 1024;
+/// One megabyte in bytes.
 pub const MB: usize = 1024 * KB;
 
 const S: u64 = 1_000_000_000; // one second in nanoseconds
@@ -51,8 +55,8 @@ pub use metrics::*;
 
 // NOTES:
 //
-// This is a simple proxy which translates requests between memcache protocol
-// and Momento gRPC. This allows for a standard memcache client to communicate
+// This is a simple proxy which translates requests between Memcached or RESP protocol
+// and Momento gRPC. This allows for a standard Memcached or RESP client to communicate
 // with the Momento cache service without any code changes.
 //
 // The following environment variables are necessary to configure the proxy
@@ -60,13 +64,13 @@ pub use metrics::*;
 //
 // MOMENTO_API_KEY - the Momento API key to use for authentication
 
-// Default for linux, should work well enough for the majority of platforms.
+/// Default for linux, should work well enough for the majority of platforms.
 pub const PAGESIZE: usize = 4096;
-// the default buffer size is matched to the upper-bound on TLS fragment size as
-// per RFC 5246 https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
+/// the default buffer size is matched to the upper-bound on TLS fragment size as
+/// per RFC 5246 https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
 pub const INITIAL_BUFFER_SIZE: usize = 16 * KB;
 
-// sets an upper bound on how large a request can be
+/// sets an upper bound on how large a request can be
 pub const MAX_REQUEST_SIZE: usize = 100 * MB;
 
 // The Momento cache client requires providing a default TTL. For the current
@@ -80,9 +84,11 @@ const DEFAULT_TTL: Duration = Duration::from_secs(3600);
 /// item within the momento cache.
 const COLLECTION_TTL: CollectionTtl = CollectionTtl::new(None, false);
 
-// we interpret TTLs the same way memcached would
+/// we interpret TTLs the same way memcached would
 pub const TIME_TYPE: TimeType = TimeType::Memcache;
 
+/// helper function to get the default buffer size as a NonZeroUsize, which is used in the config struct
+#[allow(clippy::expect_used)]
 pub const fn default_buffer_size() -> NonZeroUsize {
     NonZeroUsize::new(INITIAL_BUFFER_SIZE).expect("initial buffer size cannot be zero")
 }
@@ -207,8 +213,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .worker_threads(1)
         .thread_name("pelikan_admin")
-        .build()
-        .expect("failed to launch async runtime");
+        .build()?;
 
     let mut runtime = Builder::new_multi_thread();
 
@@ -230,10 +235,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let runtime = runtime
-        .enable_all()
-        .build()
-        .expect("failed to launch tokio runtime");
+    let runtime = runtime.enable_all().build()?;
 
     // spawn the proxy metrics
     let proxy_metrics = runtime.block_on(async { ProxyMetricsBuilder::new().build().await });
@@ -245,10 +247,7 @@ async fn spawn(
     config: MomentoProxyConfig,
     proxy_metrics: impl ProxyMetrics,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let admin_addr = config
-        .admin()
-        .socket_addr()
-        .expect("bad admin listen address");
+    let admin_addr = config.admin().socket_addr()?;
     let admin_listener = TcpListener::bind(&admin_addr).await?;
     info!("starting proxy admin listener on: {}", admin_addr);
 
@@ -257,9 +256,10 @@ async fn spawn(
         eprintln!("environment variable `MOMENTO_API_KEY` is not set");
         std::process::exit(1);
     }
-    let momento_api_key = std::env::var("MOMENTO_API_KEY").expect("MOMENTO_API_KEY must be set");
-    let credential_provider =
-        CredentialProvider::from_string(momento_api_key).unwrap_or_else(|e| {
+    let momento_api_key = std::env::var("MOMENTO_API_KEY")?;
+    // TODO: accept v2 api keys instead of v1, which is same format as disposable tokens
+    let credential_provider = CredentialProvider::from_disposable_token(momento_api_key)
+        .unwrap_or_else(|e| {
             eprintln!("failed to initialize credential provider. error: {e}");
             std::process::exit(1);
         });
@@ -272,7 +272,11 @@ async fn spawn(
     for i in 0..config.caches().len() {
         let config = config.clone();
 
-        let cache = config.caches().get(i).unwrap().clone();
+        let Some(cache) = config.caches().get(i) else {
+            eprintln!("cache config not found for index {i}");
+            std::process::exit(1);
+        };
+        let cache = cache.clone();
         let addr = match cache.socket_addr() {
             Ok(v) => v,
             Err(e) => {
@@ -330,8 +334,17 @@ async fn spawn(
                 cache.memory_cache_ttl_seconds(),
                 cache.buffer_size(),
             );
-            let tcp_listener =
-                TcpListener::from_std(tcp_listener).expect("could not convert to tokio listener");
+            let tcp_listener = match TcpListener::from_std(tcp_listener) {
+                Ok(l) => l,
+                Err(e) => {
+                    error!(
+                        "could not convert tcp listener for cache `{}` to tokio listener: {}",
+                        cache.cache_name(),
+                        e
+                    );
+                    std::process::exit(1);
+                }
+            };
 
             let local_cache_bytes = cache.memory_cache_bytes();
             let local_cache = if 0 < local_cache_bytes {

--- a/src/metrics/builder.rs
+++ b/src/metrics/builder.rs
@@ -11,12 +11,20 @@ use tonic::metadata::MetadataValue;
 
 use super::proxy::DefaultProxyMetrics;
 
+/// Builder for constructing an [`Arc<DefaultProxyMetrics>`] with an optional OTLP downstream.
 pub struct ProxyMetricsBuilder {
     batch_interval: Duration,
     batch_capacity: usize,
 }
 
+impl Default for ProxyMetricsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ProxyMetricsBuilder {
+    /// Creates a builder with default settings (1-second batch interval, 128-item capacity).
     pub fn new() -> Self {
         Self {
             batch_interval: Duration::from_secs(1),
@@ -24,6 +32,7 @@ impl ProxyMetricsBuilder {
         }
     }
 
+    /// Builds the metrics, optionally wiring up an OTLP downstream from environment variables.
     pub async fn build(self) -> Arc<DefaultProxyMetrics> {
         let (batch_sender, batch_receiver) = mpsc::channel(self.batch_capacity);
         let gauge_factory = default_gauge_factory();
@@ -35,7 +44,6 @@ impl ProxyMetricsBuilder {
             (Some(endpoint), Some(api_token)) => {
                 info!("Configuring OTLP downstream with provided endpoint and API token");
 
-                // Set up the OTLP downstream
                 let channel = get_client(
                     endpoint,
                     || {
@@ -44,22 +52,36 @@ impl ProxyMetricsBuilder {
                         })
                     },
                     goodmetrics::proto::opentelemetry::collector::metrics::v1::metrics_service_client::MetricsServiceClient::with_origin
-                ).expect("Failed to create client");
-
-                // Set up the OTLP downstream
-                let otlp_downstream = OpenTelemetryDownstream::new_with_dimensions(
-                    channel,
-                    Some(("api-token", MetadataValue::try_from(api_token).unwrap())),
-                    get_base_environment_dimensions(),
                 );
-                tokio::spawn(otlp_downstream.send_batches_forever(batch_receiver));
+                let api_token_metadata = MetadataValue::try_from(api_token);
 
-                // Set up the OpenTelemetry batcher
-                tokio::spawn(gauge_factory.clone().report_gauges_forever(
-                    self.batch_interval,
-                    batch_sender,
-                    OpentelemetryBatcher,
-                ));
+                match (channel, api_token_metadata) {
+                    (Ok(channel), Ok(api_token_metadata)) => {
+                        let otlp_downstream = OpenTelemetryDownstream::new_with_dimensions(
+                            channel,
+                            Some(("api-token", api_token_metadata)),
+                            get_base_environment_dimensions(),
+                        );
+                        tokio::spawn(otlp_downstream.send_batches_forever(batch_receiver));
+                        tokio::spawn(gauge_factory.clone().report_gauges_forever(
+                            self.batch_interval,
+                            batch_sender,
+                            OpentelemetryBatcher,
+                        ));
+                    }
+                    (Err(e), _) => {
+                        warn!(
+                            "Failed to create OTLP client, not configuring OTLP downstream: {}",
+                            e
+                        );
+                    }
+                    (_, Err(e)) => {
+                        warn!(
+                            "Failed to parse OTLP API token, not configuring OTLP downstream: {}",
+                            e
+                        );
+                    }
+                }
             }
             (None, _) => {
                 info!("OTLP endpoint not provided: not configuring OTLP downstream. Set the OTLP_ENDPOINT environment variable to configure.");

--- a/src/metrics/connection.rs
+++ b/src/metrics/connection.rs
@@ -5,12 +5,14 @@ use std::sync::{
 
 use goodmetrics::SumHandle;
 
+/// Guard that records connection open/close counts; records closure when dropped.
 pub struct ConnectionGuard {
     connections_closed: SumHandle,
     total_active_connections_count: Arc<AtomicI64>,
 }
 
 impl ConnectionGuard {
+    /// Creates a guard, incrementing the opened counter and active connection count.
     pub fn new(
         connections_opened: SumHandle,
         connections_closed: SumHandle,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,5 +1,6 @@
 use metriken::*;
 
+/// Percentile labels and their corresponding quantile values used for histogram reporting.
 pub static PERCENTILES: &[(&str, f64)] = &[
     ("p25", 25.0),
     ("p50", 50.0),
@@ -10,69 +11,91 @@ pub static PERCENTILES: &[(&str, f64)] = &[
     ("p9999", 99.99),
 ];
 
+/// Number of admin requests parsed.
 #[metric(name = "admin_request_parse")]
 pub static ADMIN_REQUEST_PARSE: Counter = Counter::new();
 
+/// Number of admin responses composed.
 #[metric(name = "admin_response_compose")]
 pub static ADMIN_RESPONSE_COMPOSE: Counter = Counter::new();
 
+/// Total backend (Momento) requests sent.
 #[metric(name = "backend_request")]
 pub static BACKEND_REQUEST: Counter = Counter::new();
 
+/// Total backend errors.
 #[metric(name = "backend_ex")]
 pub static BACKEND_EX: Counter = Counter::new();
 
+/// Backend errors due to rate limiting.
 #[metric(name = "backend_ex_rate_limited")]
 pub static BACKEND_EX_RATE_LIMITED: Counter = Counter::new();
 
+/// Backend errors due to request timeout.
 #[metric(name = "backend_ex_timeout")]
 pub static BACKEND_EX_TIMEOUT: Counter = Counter::new();
 
+/// User CPU time consumed (microseconds).
 #[metric(name = "ru_utime")]
 pub static RU_UTIME: Counter = Counter::new();
 
+/// System CPU time consumed (microseconds).
 #[metric(name = "ru_stime")]
 pub static RU_STIME: Counter = Counter::new();
 
+/// Maximum resident set size (kilobytes).
 #[metric(name = "ru_maxrss")]
 pub static RU_MAXRSS: Gauge = Gauge::new();
 
+/// Integral shared memory size.
 #[metric(name = "ru_ixrss")]
 pub static RU_IXRSS: Gauge = Gauge::new();
 
+/// Integral unshared data size.
 #[metric(name = "ru_idrss")]
 pub static RU_IDRSS: Gauge = Gauge::new();
 
+/// Integral unshared stack size.
 #[metric(name = "ru_isrss")]
 pub static RU_ISRSS: Gauge = Gauge::new();
 
+/// Number of minor (reclaimed) page faults.
 #[metric(name = "ru_minflt")]
 pub static RU_MINFLT: Counter = Counter::new();
 
+/// Number of major (I/O-requiring) page faults.
 #[metric(name = "ru_majflt")]
 pub static RU_MAJFLT: Counter = Counter::new();
 
+/// Number of times the process was swapped out.
 #[metric(name = "ru_nswap")]
 pub static RU_NSWAP: Counter = Counter::new();
 
+/// Number of block input operations.
 #[metric(name = "ru_inblock")]
 pub static RU_INBLOCK: Counter = Counter::new();
 
+/// Number of block output operations.
 #[metric(name = "ru_oublock")]
 pub static RU_OUBLOCK: Counter = Counter::new();
 
+/// Number of IPC messages sent.
 #[metric(name = "ru_msgsnd")]
 pub static RU_MSGSND: Counter = Counter::new();
 
+/// Number of IPC messages received.
 #[metric(name = "ru_msgrcv")]
 pub static RU_MSGRCV: Counter = Counter::new();
 
+/// Number of signals received.
 #[metric(name = "ru_nsignals")]
 pub static RU_NSIGNALS: Counter = Counter::new();
 
+/// Number of voluntary context switches.
 #[metric(name = "ru_nvcsw")]
 pub static RU_NVCSW: Counter = Counter::new();
 
+/// Number of involuntary context switches.
 #[metric(name = "ru_nivcsw")]
 pub static RU_NIVCSW: Counter = Counter::new();
 
@@ -80,6 +103,7 @@ mod builder;
 mod connection;
 mod proxy;
 mod rpc;
+/// Gauge factory helper utilities.
 pub mod util;
 
 pub use builder::ProxyMetricsBuilder;

--- a/src/metrics/proxy.rs
+++ b/src/metrics/proxy.rs
@@ -14,62 +14,111 @@ use goodmetrics::{GaugeFactory, SumHandle};
 
 use super::{RpcCallGuard, RpcMetrics};
 
+/// Metrics for tracking connection lifecycle events.
 pub trait ConnectionMetrics: Clone + Send + Sync + 'static {
+    /// Begins tracking a new connection; returns a guard that records closure on drop.
     fn begin_connection(&self) -> ConnectionGuard;
 }
 
+/// Metrics for tracking Memcached protocol RPC calls.
 pub trait MemcachedMetrics: Clone + Send + Sync + 'static {
+    /// Begins tracking a `get` RPC call.
     fn begin_memcached_get(&self) -> RpcCallGuard;
+    /// Begins tracking a `set` RPC call.
     fn begin_memcached_set(&self) -> RpcCallGuard;
+    /// Begins tracking a `delete` RPC call.
     fn begin_memcached_delete(&self) -> RpcCallGuard;
+    /// Begins tracking an unimplemented command RPC call.
     fn begin_memcached_unimplemented(&self) -> RpcCallGuard;
 }
 
+/// Metrics for tracking RESP protocol RPC calls.
 pub trait RespMetrics: Clone + Send + Sync + 'static {
+    /// Begins tracking a `del` RPC call.
     fn begin_resp_del(&self) -> RpcCallGuard;
+    /// Begins tracking a `get` RPC call.
     fn begin_resp_get(&self) -> RpcCallGuard;
+    /// Begins tracking a `hdel` RPC call.
     fn begin_resp_hdel(&self) -> RpcCallGuard;
+    /// Begins tracking a `hexists` RPC call.
     fn begin_resp_hexists(&self) -> RpcCallGuard;
+    /// Begins tracking a `hget` RPC call.
     fn begin_resp_hget(&self) -> RpcCallGuard;
+    /// Begins tracking a `hgetall` RPC call.
     fn begin_resp_hgetall(&self) -> RpcCallGuard;
+    /// Begins tracking a `hincrby` RPC call.
     fn begin_resp_hincrby(&self) -> RpcCallGuard;
+    /// Begins tracking a `hkeys` RPC call.
     fn begin_resp_hkeys(&self) -> RpcCallGuard;
+    /// Begins tracking a `hlen` RPC call.
     fn begin_resp_hlen(&self) -> RpcCallGuard;
+    /// Begins tracking a `hmget` RPC call.
     fn begin_resp_hmget(&self) -> RpcCallGuard;
+    /// Begins tracking a `hset` RPC call.
     fn begin_resp_hset(&self) -> RpcCallGuard;
+    /// Begins tracking a `hvals` RPC call.
     fn begin_resp_hvals(&self) -> RpcCallGuard;
+    /// Begins tracking a `lindex` RPC call.
     fn begin_resp_lindex(&self) -> RpcCallGuard;
+    /// Begins tracking a `llen` RPC call.
     fn begin_resp_llen(&self) -> RpcCallGuard;
+    /// Begins tracking a `lpop` RPC call.
     fn begin_resp_lpop(&self) -> RpcCallGuard;
+    /// Begins tracking a `lrange` RPC call.
     fn begin_resp_lrange(&self) -> RpcCallGuard;
+    /// Begins tracking a `lpush` RPC call.
     fn begin_resp_lpush(&self) -> RpcCallGuard;
+    /// Begins tracking a `rpush` RPC call.
     fn begin_resp_rpush(&self) -> RpcCallGuard;
+    /// Begins tracking a `rpop` RPC call.
     fn begin_resp_rpop(&self) -> RpcCallGuard;
+    /// Begins tracking a `set` RPC call.
     fn begin_resp_set(&self) -> RpcCallGuard;
+    /// Begins tracking a `sadd` RPC call.
     fn begin_resp_sadd(&self) -> RpcCallGuard;
+    /// Begins tracking a `srem` RPC call.
     fn begin_resp_srem(&self) -> RpcCallGuard;
+    /// Begins tracking a `sdiff` RPC call.
     fn begin_resp_sdiff(&self) -> RpcCallGuard;
+    /// Begins tracking a `sunion` RPC call.
     fn begin_resp_sunion(&self) -> RpcCallGuard;
+    /// Begins tracking a `sinter` RPC call.
     fn begin_resp_sinter(&self) -> RpcCallGuard;
+    /// Begins tracking a `smembers` RPC call.
     fn begin_resp_smembers(&self) -> RpcCallGuard;
+    /// Begins tracking a `sismember` RPC call.
     fn begin_resp_sismember(&self) -> RpcCallGuard;
+    /// Begins tracking a `zcard` RPC call.
     fn begin_resp_zcard(&self) -> RpcCallGuard;
+    /// Begins tracking a `zincrby` RPC call.
     fn begin_resp_zincrby(&self) -> RpcCallGuard;
+    /// Begins tracking a `zscore` RPC call.
     fn begin_resp_zscore(&self) -> RpcCallGuard;
+    /// Begins tracking a `zmscore` RPC call.
     fn begin_resp_zmscore(&self) -> RpcCallGuard;
+    /// Begins tracking a `zrem` RPC call.
     fn begin_resp_zrem(&self) -> RpcCallGuard;
+    /// Begins tracking a `zrank` RPC call.
     fn begin_resp_zrank(&self) -> RpcCallGuard;
+    /// Begins tracking a `zrange` RPC call.
     fn begin_resp_zrange(&self) -> RpcCallGuard;
+    /// Begins tracking a `zadd` RPC call.
     fn begin_resp_zadd(&self) -> RpcCallGuard;
+    /// Begins tracking a `zrevrank` RPC call.
     fn begin_resp_zrevrank(&self) -> RpcCallGuard;
+    /// Begins tracking a `zcount` RPC call.
     fn begin_resp_zcount(&self) -> RpcCallGuard;
+    /// Begins tracking a `zunionstore` RPC call.
     fn begin_resp_zunionstore(&self) -> RpcCallGuard;
+    /// Begins tracking an unimplemented RESP command.
     fn begin_resp_unimplemented(&self) -> RpcCallGuard;
 }
 
+/// Combined proxy metrics trait covering connections, Memcached, and RESP RPCs.
 pub trait ProxyMetrics: ConnectionMetrics + MemcachedMetrics + RespMetrics {}
 impl<T: ConnectionMetrics + MemcachedMetrics + RespMetrics> ProxyMetrics for T {}
 
+/// Default implementation of [`ProxyMetrics`] backed by goodmetrics histograms.
 #[derive(Clone, Debug)]
 pub struct DefaultProxyMetrics {
     // connection handles

--- a/src/metrics/rpc.rs
+++ b/src/metrics/rpc.rs
@@ -15,6 +15,7 @@ use super::util::{
     proxy_request_latency_timeout_histogram,
 };
 
+/// Latency histogram handles for a single RPC type.
 #[derive(Clone, Debug)]
 pub struct RpcMetrics {
     rpc: &'static str,
@@ -27,6 +28,7 @@ pub struct RpcMetrics {
 }
 
 impl RpcMetrics {
+    /// Creates histogram handles for the given RPC name.
     pub fn new(gauge_factory: &GaugeFactory, rpc: &'static str) -> Self {
         Self {
             rpc,
@@ -39,6 +41,7 @@ impl RpcMetrics {
         }
     }
 
+    /// Starts a new RPC call tracking guard for this metric.
     pub fn record_api_call(&self) -> RpcCallGuard {
         RpcCallGuard::new(
             self.rpc,
@@ -52,6 +55,7 @@ impl RpcMetrics {
     }
 }
 
+/// Guard that records latency when a single RPC call completes or is dropped (timeout).
 #[derive(Clone)]
 pub struct RpcCallGuard {
     rpc: &'static str,
@@ -66,6 +70,7 @@ pub struct RpcCallGuard {
 }
 
 impl RpcCallGuard {
+    /// Creates a new guard, capturing the start time.
     pub fn new(
         rpc: &'static str,
         latency_ok: HistogramHandle,
@@ -88,6 +93,7 @@ impl RpcCallGuard {
         }
     }
 
+    /// Records a successful RPC completion.
     pub fn complete_ok(&mut self) {
         if let Ok(false) =
             self.recorded
@@ -98,6 +104,7 @@ impl RpcCallGuard {
         }
     }
 
+    /// Records a failed RPC completion.
     pub fn complete_error(&mut self) {
         if let Ok(false) =
             self.recorded
@@ -108,6 +115,7 @@ impl RpcCallGuard {
         }
     }
 
+    /// Records completion based on whether `result` is `Ok` or `Err`.
     pub fn complete<T, E>(&mut self, result: &Result<T, E>) {
         match result {
             Ok(_) => self.complete_ok(),
@@ -115,6 +123,7 @@ impl RpcCallGuard {
         };
     }
 
+    /// Records a cache miss. May be called multiple times for multi-key requests.
     pub fn complete_miss(&mut self) {
         // Might observe multiple hits if multiple keys are requested, so update
         // the recorded flag but don't check it before recording the latency.
@@ -126,6 +135,7 @@ impl RpcCallGuard {
             .observe(self.start_time.elapsed().as_nanos() as i64);
     }
 
+    /// Records a hit served from the local in-process memory cache.
     pub fn complete_hit_mcache(&mut self) {
         // Might observe multiple hits if multiple keys are requested, so update
         // the recorded flag but don't check it before recording the latency.
@@ -137,6 +147,7 @@ impl RpcCallGuard {
             .observe(self.start_time.elapsed().as_nanos() as i64);
     }
 
+    /// Records a hit served from the Momento backend.
     pub fn complete_hit_momento(&mut self) {
         // Might observe multiple hits if multiple keys are requested, so update
         // the recorded flag but don't check it before recording the latency.
@@ -162,6 +173,7 @@ impl Drop for RpcCallGuard {
     }
 }
 
+/// Awaits `fut` and records its success or failure via `recorder`.
 pub async fn with_rpc_call_guard<T, E, F>(mut recorder: RpcCallGuard, fut: F) -> Result<T, E>
 where
     F: Future<Output = Result<T, E>>,
@@ -171,10 +183,13 @@ where
     result
 }
 
+/// Implemented by response types that embed a protocol-level error.
 pub trait ResponseWrappingError {
+    /// Returns `true` if the response represents an error.
     fn is_error(&self) -> bool;
 }
 
+/// Awaits `fut` and records ok/error based on whether the successful response wraps an error.
 pub async fn with_wrapped_error_response_rpc_call_guard<R: ResponseWrappingError, E, F>(
     mut recorder: RpcCallGuard,
     fut: F,

--- a/src/metrics/util.rs
+++ b/src/metrics/util.rs
@@ -1,9 +1,11 @@
 use goodmetrics::{GaugeDimensions, GaugeFactory, HistogramHandle, StatisticSetHandle, SumHandle};
 
+/// Creates a sum-aggregated gauge for the proxy with the given name.
 pub fn proxy_sum_gauge(g: &GaugeFactory, name: &'static str) -> SumHandle {
     g.dimensioned_gauge_sum("momento_proxy", name, Default::default())
 }
 
+/// Creates a statistic-set gauge for the proxy with the given name.
 pub fn proxy_statistic_set_gauge(g: &GaugeFactory, name: &'static str) -> StatisticSetHandle {
     g.dimensioned_gauge_statistic_set("momento_proxy", name, Default::default())
 }
@@ -33,6 +35,7 @@ fn proxy_hit_response_latency_histogram(
     )
 }
 
+/// Creates a latency histogram for cache hits with a `source` dimension (e.g. `"mcache"` or `"momento"`).
 pub fn proxy_request_latency_hit_histogram(
     g: &GaugeFactory,
     rpc: &'static str,
@@ -41,6 +44,7 @@ pub fn proxy_request_latency_hit_histogram(
     proxy_hit_response_latency_histogram(g, rpc, "hit", source)
 }
 
+/// Creates a latency histogram for cache misses.
 pub fn proxy_request_latency_miss_histogram(
     g: &GaugeFactory,
     rpc: &'static str,
@@ -48,10 +52,12 @@ pub fn proxy_request_latency_miss_histogram(
     proxy_request_latency_histogram(g, rpc, "miss")
 }
 
+/// Creates a latency histogram for successful (ok) RPC outcomes.
 pub fn proxy_request_latency_ok_histogram(g: &GaugeFactory, rpc: &'static str) -> HistogramHandle {
     proxy_request_latency_histogram(g, rpc, "ok")
 }
 
+/// Creates a latency histogram for error RPC outcomes.
 pub fn proxy_request_latency_error_histogram(
     gauge_factory: &GaugeFactory,
     rpc: &'static str,
@@ -59,6 +65,7 @@ pub fn proxy_request_latency_error_histogram(
     proxy_request_latency_histogram(gauge_factory, rpc, "error")
 }
 
+/// Creates a latency histogram for timed-out RPC outcomes.
 pub fn proxy_request_latency_timeout_histogram(
     gauge_factory: &GaugeFactory,
     rpc: &'static str,

--- a/src/momento_proxy.rs
+++ b/src/momento_proxy.rs
@@ -16,17 +16,12 @@ use serde::{Deserialize, Serialize};
 
 use std::io::Read;
 
-#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Serialize, Default, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum Protocol {
+    #[default]
     Memcache,
     Resp,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Self::Memcache
-    }
 }
 
 // support for memcache flags is on by default
@@ -78,6 +73,7 @@ pub struct Cache {
     buffer_size: NonZeroUsize,
 }
 
+#[allow(clippy::expect_used)]
 const fn four() -> NonZeroUsize {
     NonZeroUsize::new(4).expect("4 is nonzero")
 }
@@ -147,10 +143,7 @@ impl MomentoProxyConfig {
             Ok(t) => Ok(t),
             Err(e) => {
                 eprintln!("{e}");
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Error parsing config",
-                ))
+                Err(std::io::Error::other("Error parsing config"))
             }
         }
     }

--- a/src/protocol/memcache/get.rs
+++ b/src/protocol/memcache/get.rs
@@ -97,7 +97,10 @@ async fn run_get(
                     recorder.complete_hit_momento();
                     klog_1(&"get", &key, Status::Hit, length);
                     Ok(Some(protocol_memcache::Value::new(
-                        key, flags, None, &value[4..],
+                        key,
+                        flags,
+                        None,
+                        &value[4..],
                     )))
                 } else {
                     let length = value.len();
@@ -123,7 +126,7 @@ async fn run_get(
             BACKEND_EX.increment();
 
             klog_1(&"get", &key, Status::ServerError, 0);
-            Err(Error::new(ErrorKind::Other, format!("{e}")))
+            Err(Error::other(format!("{e}")))
         }
         Err(_) => {
             // we had a timeout, incr stats and move on
@@ -131,7 +134,7 @@ async fn run_get(
             BACKEND_EX_TIMEOUT.increment();
 
             klog_1(&"get", &key, Status::Timeout, 0);
-            Err(Error::new(ErrorKind::Other, format!("backend timeout")))
+            Err(Error::other("backend timeout"))
         }
     }
 }

--- a/src/protocol/memcache/set.rs
+++ b/src/protocol/memcache/set.rs
@@ -47,7 +47,7 @@ pub async fn set(
         // (1) A proxy process restart doesn't degrade performance (cache warms on read)
         // (2) Multiple proxies each keep a warm local cache, even if writes are done by others
         let flags = if flags { request.flags() } else { 0 };
-        let value = protocol_memcache::Value::new(&key, flags, None, &request.value());
+        let value = protocol_memcache::Value::new(&key, flags, None, request.value());
         memory_cache.set(key.to_vec(), CacheValue::Memcached { value });
     }
 

--- a/src/protocol/resp/sdiff.rs
+++ b/src/protocol/resp/sdiff.rs
@@ -9,7 +9,7 @@ use momento::{cache::SetFetchResponse, CacheClient};
 use protocol_resp::{SetDiff, SDIFF, SDIFF_EX};
 use tokio::time;
 
-use crate::ProxyResult;
+use crate::{ProxyError, ProxyResult};
 
 use super::update_method_metrics;
 
@@ -23,10 +23,9 @@ pub async fn sdiff(
         let timeout = Duration::from_millis(200);
 
         // Note: the resp parser validates that SetDiff has at least one key.
-        let (head, rest) = req
-            .keys()
-            .split_first()
-            .expect("got an invalid set difference request");
+        let (head, rest) = req.keys().split_first().ok_or_else(|| {
+            ProxyError::from(std::io::Error::other("invalid set difference request"))
+        })?;
         let head = &**head;
 
         let response = time::timeout(timeout, client.set_fetch(cache_name, head)).await??;

--- a/src/protocol/resp/sinter.rs
+++ b/src/protocol/resp/sinter.rs
@@ -10,7 +10,7 @@ use protocol_resp::{SetIntersect, SINTER, SINTER_EX};
 use std::collections::HashSet;
 use tokio::time;
 
-use crate::ProxyResult;
+use crate::{ProxyError, ProxyResult};
 
 use super::update_method_metrics;
 
@@ -24,10 +24,9 @@ pub async fn sinter(
         let timeout = Duration::from_millis(200);
 
         // Note: the resp parser validates that SetInter has at least one key.
-        let (head, rest) = req
-            .keys()
-            .split_first()
-            .expect("got an invalid set difference request");
+        let (head, rest) = req.keys().split_first().ok_or_else(|| {
+            ProxyError::from(std::io::Error::other("invalid set intersect request"))
+        })?;
         let head = &**head;
 
         let response = time::timeout(timeout, client.set_fetch(cache_name, head)).await??;

--- a/src/protocol/resp/utils.rs
+++ b/src/protocol/resp/utils.rs
@@ -5,8 +5,6 @@
 use momento::MomentoError;
 use std::future::Future;
 
-use crate::error::ProxyError;
-
 pub(crate) fn momento_error_to_resp_error(buf: &mut Vec<u8>, command: &str, error: MomentoError) {
     use crate::BACKEND_EX;
 
@@ -27,26 +25,16 @@ pub(crate) async fn update_method_metrics<T, E>(
     })
 }
 
-pub(crate) fn parse_score_boundary_as_integer(value: &[u8]) -> Result<i32, ProxyError> {
+pub(crate) fn parse_score_boundary_as_integer(value: &[u8]) -> Result<i32, std::io::Error> {
     let index = std::str::from_utf8(value)
-        .map_err(|_| {
-            ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ZRANGE index is not valid utf8",
-            ))
-        })?
+        .map_err(|_| std::io::Error::other("ZRANGE index is not valid utf8"))?
         .parse::<i32>()
-        .map_err(|_| {
-            ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ZRANGE index is not an integer",
-            ))
-        })?;
+        .map_err(|_| std::io::Error::other("ZRANGE index is not an integer"))?;
     Ok(index)
 }
 
 // Returns a tuple of (value, is_exclusive)
-pub(crate) fn parse_score_boundary_as_float(value: &[u8]) -> Result<(f64, bool), ProxyError> {
+pub(crate) fn parse_score_boundary_as_float(value: &[u8]) -> Result<(f64, bool), std::io::Error> {
     // First check if the value is +inf or -inf
     if value == b"+inf" {
         return Ok((f64::INFINITY, false));
@@ -63,19 +51,9 @@ pub(crate) fn parse_score_boundary_as_float(value: &[u8]) -> Result<(f64, bool),
     };
 
     let score = std::str::from_utf8(number)
-        .map_err(|_| {
-            ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ZRANGE score is not valid utf8",
-            ))
-        })?
+        .map_err(|_| std::io::Error::other("ZRANGE score is not valid utf8"))?
         .parse::<f64>()
-        .map_err(|_| {
-            ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "ZRANGE score is not a float",
-            ))
-        })?;
+        .map_err(|_| std::io::Error::other("ZRANGE score is not a float"))?;
 
     if exclusive_symbol {
         Ok((score, true))

--- a/src/protocol/resp/zadd.rs
+++ b/src/protocol/resp/zadd.rs
@@ -33,8 +33,7 @@ pub async fn zadd(
             || req.optional_args().lt
         {
             klog_1(&"zadd", &req.key(), Status::ServerError, 0);
-            return Err(ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(ProxyError::from(std::io::Error::other(
                 "Momento proxy does not support CH, XX, NX, GT, or LT optional arguments",
             )));
         }

--- a/src/protocol/resp/zrange.rs
+++ b/src/protocol/resp/zrange.rs
@@ -29,8 +29,7 @@ pub async fn zrange(
     update_method_metrics(&ZRANGE, &ZRANGE_EX, async move {
         if *req.range_type() == RangeType::ByLex {
             klog_1(&"zrange", &req.key(), Status::ServerError, 0);
-            return Err(ProxyError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(ProxyError::from(std::io::Error::other(
                 "Momento proxy does not support BYLEX for ZRANGE",
             )));
         }
@@ -119,10 +118,7 @@ pub async fn zrange(
             }
             _ => {
                 klog_1(&"zrange", &req.key(), Status::ServerError, 0);
-                return Err(ProxyError::from(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "malformed command",
-                )));
+                return Err(ProxyError::from(std::io::Error::other("malformed command")));
             }
         };
 


### PR DESCRIPTION
Since we're starting development on the proxy again, seemed like a good idea to re-enable the lint/format PR check, fix the existing lint errors, and lightly update the readme and doc comments.
There should be no major changes to functionality.

Current planned follow ups: use v2 api keys instead of v1, enable multi-region writes