### PR TITLE
feat: require v2 api key and service endpoint

### DIFF
--- a/config/momento_proxy.toml
+++ b/config/momento_proxy.toml
@@ -36,6 +36,9 @@ default_ttl = 900
 # Defaults to 16 KiB. Can be tuned for performance based on item size distribution for the cache.
 # Values are rounded to the nearest multiple of 4KiB before use.
 # buffer_size = 16384
+# The primary Momento service endpoint to connect to for this cache. 
+# See https://docs.momentohq.com/platform/regions for the full list of available SDK endpoints.
+primary_endpoint = "cell-us-east-1-1.prod.a.momentohq.com"
 
 # For compatibility reasons, by default memcache flags are stored with the value. If you are
 # __certain__ you do not need this, you can opt-out and save 4 bytes per stored value. If any
@@ -58,6 +61,9 @@ default_ttl = 1800
 # connection_count = 4
 # the protocol can be "memcache" or "resp" (Redis), the default is memcache
 protocol = "memcache"
+# The primary Momento service endpoint to connect to for this cache. 
+# See https://docs.momentohq.com/platform/regions for the full list of available SDK endpoints.
+primary_endpoint = "cell-us-east-1-1.prod.a.momentohq.com"
 
 # For compatibility reasons, by default memcache flags are stored with the value. If you are
 # __certain__ you do not need this, you can opt-out and save 4 bytes per stored value. If any
@@ -80,6 +86,9 @@ default_ttl = 300
 # connection_count = 4
 # the protocol can be "memcache" or "resp" (Redis), the default is memcache
 protocol = "resp"
+# The primary Momento service endpoint to connect to for this cache. 
+# See https://docs.momentohq.com/platform/regions for the full list of available SDK endpoints.
+primary_endpoint = "cell-us-east-1-1.prod.a.momentohq.com"
 
 # Configure the proxy's logging
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,12 +257,6 @@ async fn spawn(
         std::process::exit(1);
     }
     let momento_api_key = std::env::var("MOMENTO_API_KEY")?;
-    // TODO: accept v2 api keys instead of v1, which is same format as disposable tokens
-    let credential_provider = CredentialProvider::from_disposable_token(momento_api_key)
-        .unwrap_or_else(|e| {
-            eprintln!("failed to initialize credential provider. error: {e}");
-            std::process::exit(1);
-        });
 
     if config.caches().is_empty() {
         eprintln!("no caches specified in the config");
@@ -289,10 +283,28 @@ async fn spawn(
             }
         };
 
+        let primary_endpoint = cache.primary_endpoint();
+        if primary_endpoint.is_empty() {
+            eprintln!(
+                "primary endpoint is not set for cache `{}`. Please set the `primary_endpoint` field in the config file for this cache.",
+                cache.cache_name(),
+            );
+            std::process::exit(1);
+        }
+        let credential_provider =
+            CredentialProvider::from_api_key_v2(momento_api_key.clone(), primary_endpoint)
+                .unwrap_or_else(|e| {
+                    eprintln!(
+                        "failed to initialize credential provider for cache `{}`: {e} (MOMENTO_API_KEY must be a v2 API key)",
+                        cache.cache_name()
+                    );
+                    std::process::exit(1);
+                });
+
         let client_builder = CacheClient::builder()
             .default_ttl(DEFAULT_TTL)
             .configuration(configurations::Laptop::latest())
-            .credential_provider(credential_provider.clone())
+            .credential_provider(credential_provider)
             .with_num_connections(cache.connection_count());
 
         let tcp_listener = match std::net::TcpListener::bind(addr) {

--- a/src/momento_proxy.rs
+++ b/src/momento_proxy.rs
@@ -71,6 +71,8 @@ pub struct Cache {
     memory_cache_ttl_seconds: u64,
     #[serde(default = "default_buffer_size")]
     buffer_size: NonZeroUsize,
+    #[serde(default)]
+    primary_endpoint: String,
 }
 
 #[allow(clippy::expect_used)]
@@ -130,6 +132,11 @@ impl Cache {
         // rounds the buffer size up to the next nearest multiple of the
         // pagesize
         std::cmp::max(1, self.buffer_size.get()).div_ceil(PAGESIZE)
+    }
+
+    /// Returns the primary Momento service endpoint that requests will be sent to
+    pub fn primary_endpoint(&self) -> String {
+        self.primary_endpoint.clone()
     }
 }
 


### PR DESCRIPTION
Switch to accepting only v2 api keys and a primary endpoint.
Follow-up PR will extend the proxy to support multi-region operations and accept additional endpoints for a single cache.