### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -20,6 +20,13 @@ jobs:
       tag_name: ${{ steps.rp.outputs.tag_name }}
       version: ${{ steps.rp.outputs.version }}
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -27,7 +34,7 @@ jobs:
         id: rp
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   publish-docker:
     name: Publish Docker Image

--- a/src/protocol/resp/hkeys.rs
+++ b/src/protocol/resp/hkeys.rs
@@ -45,7 +45,7 @@ pub async fn hkeys(
 
                 response_buf.extend_from_slice(format!("*{}\r\n", map.len()).as_bytes());
 
-                for (field, _value) in map.iter() {
+                for field in map.keys() {
                     let field_header = format!("${}\r\n", field.len());
 
                     response_buf.extend_from_slice(field_header.as_bytes());

--- a/src/protocol/resp/hvals.rs
+++ b/src/protocol/resp/hvals.rs
@@ -45,7 +45,7 @@ pub async fn hvals(
 
                 response_buf.extend_from_slice(format!("*{}\r\n", map.len()).as_bytes());
 
-                for (_filed, value) in map.iter() {
+                for value in map.values() {
                     let value_header = format!("${}\r\n", value.len());
 
                     response_buf.extend_from_slice(value_header.as_bytes());


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
